### PR TITLE
Fix typo in Shell `foldIO` law

### DIFF
--- a/src/Turtle/Shell.hs
+++ b/src/Turtle/Shell.hs
@@ -47,7 +47,7 @@
 
 > -- For every shell `s`:
 > foldIO s (FoldM step begin done) = do
->     x  <- step
+>     x  <- begin
 >     x' <- foldIO s (FoldM step (return x) return)
 >     done x'
 


### PR DESCRIPTION
Presumably we ought to be initializing the accumulator with `begin` rather than `step` :)