### PR TITLE
Fix haddock for fp

### DIFF
--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -180,7 +180,7 @@ g = makeFormat (\n -> pack (showGFloat (Just 6) n ""))
 s :: Format r (Text -> r)
 s = makeFormat id
 
-{-| `Format` a `Filesystem.Path.CurrentOS` into `Text`
+{-| `Format` a `Filesystem.Path.CurrentOS.FilePath` into `Text`
 -}
 fp :: Format r (FilePath -> r)
 fp = makeFormat (\fpath -> either id id (toText fpath))

--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -181,6 +181,10 @@ s :: Format r (Text -> r)
 s = makeFormat id
 
 {-| `Format` a `Filesystem.Path.CurrentOS.FilePath` into `Text`
+
+>>> import Filesystem.Path.CurrentOS((</>))
+>>> format fp ("usr" </> "lib")
+"usr/lib"
 -}
 fp :: Format r (FilePath -> r)
 fp = makeFormat (\fpath -> either id id (toText fpath))

--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -180,6 +180,11 @@ g = makeFormat (\n -> pack (showGFloat (Just 6) n ""))
 s :: Format r (Text -> r)
 s = makeFormat id
 
+{-| `Format` a `Filesystem.Path.CurrentOS` into `Text`
+-}
+fp :: Format r (FilePath -> r)
+fp = makeFormat (\fpath -> either id id (toText fpath))
+
 {-| Convert a `Show`able value to `Text`
 
     Short-hand for @(format w)@
@@ -187,11 +192,5 @@ s = makeFormat id
 >>> repr (1,2)
 "(1,2)"
 -}
-
-{-| `Format` a `Filesystem.Path.CurrentOS` into `Text`
--}
-fp :: Format r (FilePath -> r)
-fp = makeFormat (\fpath -> either id id (toText fpath))
-
 repr :: Show a => a -> Text
 repr = format w


### PR DESCRIPTION
I have messed the haddock for `repl`. Sorry about that. This is the fix.

Do you think it worths adding a doctest ? 

```
>>> format fp ("~/.test.txt" ::FilePath)
"~/.test.txt"
```
or just:
```
>>> format fp "~/.test.txt"
"~/.test.txt"
```