### PR TITLE
Relax the return type of exit

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -533,7 +533,7 @@ sleep n = threadDelay (truncate (n * 10^(6::Int)))
 
     An exit code of @0@ indicates success
 -}
-exit :: Int -> IO ()
+exit :: Int -> IO a
 exit 0 = exitWith  ExitSuccess
 exit n = exitWith (ExitFailure n)
 


### PR DESCRIPTION
`exit` doesn't need to return a unit. This change is useful when you write something like below:

```haskell
action :: IO a
action = doSomething
  `catch` \e -> do
    doSomethingElse e
    exit 1 -- this doesn't type check!

doSomething :: IO a
```