### PR TITLE
Turtle.Options module

### DIFF
--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -67,6 +67,7 @@ module Turtle (
     -- * Modules
       module Turtle.Format
     , module Turtle.Pattern
+    , module Turtle.Options
     , module Turtle.Shell
     , module Turtle.Prelude
     , module Control.Applicative
@@ -88,6 +89,7 @@ module Turtle (
 
 import Turtle.Format
 import Turtle.Pattern
+import Turtle.Options
 import Turtle.Shell
 import Turtle.Prelude
 import Control.Applicative

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -40,6 +40,14 @@ instance Option Text where
     type OptionFields Text = Opts.ArgumentFields
     opt = Opts.argument (fmap Text.pack Opts.readerAsk)
 
+instance Option Int where
+    type OptionFields Int = Opts.ArgumentFields
+    opt = Opts.argument Opts.auto
+
+instance Option Integer where
+    type OptionFields Integer = Opts.ArgumentFields
+    opt = Opts.argument Opts.auto
+
 flag :: a -> a -> Opts.Mod Opts.FlagFields a -> Opts.Parser a
 flag = Opts.flag
 

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -67,7 +67,7 @@ parameter
     -> Optional HelpMessage
     -> Parser a
 parameter paramRead paramName helpMessage
-   = Opts.option (parameterReadToReadM paramRead)
+   = Opts.argument (parameterReadToReadM paramRead)
    $ Opts.metavar (Text.unpack (getParameterName paramName))
   <> optionalOr (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
@@ -78,10 +78,10 @@ parameterRead :: (Text -> Maybe a) -> ParameterRead a
 parameterRead f = ParameterRead (ReaderT (f . Text.pack))
 
 pAuto :: Read a => ParameterRead a
-pAuto = ParameterRead (ReaderT readMaybe)
+pAuto = parameterRead (readMaybe . Text.unpack)
 
 pText :: ParameterRead Text
-pText = ParameterRead (ReaderT $ \s -> Just (Text.pack s))
+pText = parameterRead Just
 
 pInteger :: ParameterRead Integer
 pInteger = pAuto

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -11,6 +11,7 @@ module Turtle.Options
     , switch
     , arg
     , argRead
+    , argIntegral
     , argText
     , argInteger
     , argInt
@@ -65,6 +66,9 @@ arg argParse argName helpMessage
 
 argRead :: Read a => ArgName -> Optional HelpMessage -> Parser a
 argRead = arg (readMaybe . Text.unpack)
+
+argIntegral :: Integral a => ArgName -> Optional HelpMessage -> Parser a
+argIntegral argName helpMessage = fmap fromInteger (argRead argName helpMessage)
 
 argText :: ArgName -> Optional HelpMessage -> Parser Text
 argText = arg Just

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- TODO: documentation
+
+module Turtle.Options
+    ( Opts.Parser
+    , Opts.InfoMod
+    , options
+    , opt
+    , flag
+    , metavar
+    , helpmsg
+    , shortname
+    , longname
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Control.Applicative
+import Control.Monad.IO.Class
+import qualified Options.Applicative as Opts
+import qualified Options.Applicative.Types as Opts
+import qualified Options.Applicative.Builder.Internal as Opts
+
+options :: MonadIO io => Opts.Parser a -> Opts.InfoMod a -> io a
+options parser info = liftIO
+    (Opts.execParser (Opts.info (Opts.helper <*> parser) info))
+
+class Option opt where
+    type OptionFields opt :: * -> *
+    opt :: Opts.Mod (OptionFields opt) opt -> Opts.Parser opt
+
+instance Option Bool where
+    type OptionFields Bool = Opts.FlagFields
+    opt = Opts.switch
+
+instance Option Text where
+    type OptionFields Text = Opts.ArgumentFields
+    opt = Opts.argument (fmap Text.pack Opts.readerAsk)
+
+flag :: a -> a -> Opts.Mod Opts.FlagFields a -> Opts.Parser a
+flag = Opts.flag
+
+metavar :: Opts.HasMetavar f => Text -> Opts.Mod f a
+metavar str = Opts.metavar (Text.unpack str)
+
+helpmsg :: Text -> Opts.Mod f a
+helpmsg str = Opts.help (Text.unpack str)
+
+shortname :: Opts.HasName f => Char -> Opts.Mod f a
+shortname = Opts.short
+
+longname :: Opts.HasName f => Text -> Opts.Mod f a
+longname str = Opts.long (Text.unpack str)

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -12,6 +12,8 @@ module Turtle.Options
     , helpmsg
     , shortname
     , longname
+    , header
+    , footer
     ) where
 
 import Data.Text (Text)
@@ -42,13 +44,19 @@ flag :: a -> a -> Opts.Mod Opts.FlagFields a -> Opts.Parser a
 flag = Opts.flag
 
 metavar :: Opts.HasMetavar f => Text -> Opts.Mod f a
-metavar str = Opts.metavar (Text.unpack str)
+metavar t = Opts.metavar (Text.unpack t)
 
 helpmsg :: Text -> Opts.Mod f a
-helpmsg str = Opts.help (Text.unpack str)
+helpmsg t = Opts.help (Text.unpack t)
 
 shortname :: Opts.HasName f => Char -> Opts.Mod f a
 shortname = Opts.short
 
 longname :: Opts.HasName f => Text -> Opts.Mod f a
 longname str = Opts.long (Text.unpack str)
+
+header :: Text -> Opts.InfoMod a
+header t = Opts.header (Text.unpack t)
+
+footer :: Text -> Opts.InfoMod a
+footer t = Opts.footer (Text.unpack t)

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -4,17 +4,17 @@
 
 module Turtle.Options
     ( Parser
-    , ParameterName(..)
+    , ArgName(..)
     , LongName(..)
     , HelpMessage(..)
     , options
     , switch
-    , parameter
-    , parameterAuto
-    , parameterText
-    , parameterInteger
-    , parameterInt
-    , parameterDouble
+    , arg
+    , argRead
+    , argText
+    , argInteger
+    , argInt
+    , argDouble
     ) where
 
 import Data.Monoid
@@ -35,7 +35,7 @@ options header parser = liftIO
     $ Opts.execParser
     $ Opts.info (Opts.helper <*> parser) (Opts.header (Text.unpack header))
 
-newtype ParameterName = ParameterName { getParameterName :: Text }
+newtype ArgName = ArgName { getArgName :: Text }
     deriving (IsString)
 
 newtype LongName = LongName { getLongName :: Text }
@@ -54,33 +54,32 @@ switch longName helpMessage
   <> foldMap (Opts.short . fst) (Text.uncons (getLongName longName))
   <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
-parameter
-    :: (Text -> Maybe a)
-    -> ParameterName
+arg :: (Text -> Maybe a)
+    -> ArgName
     -> Optional HelpMessage
     -> Parser a
-parameter paramRead paramName helpMessage
-   = Opts.argument (parameterReadToReadM paramRead)
-   $ Opts.metavar (Text.unpack (getParameterName paramName))
+arg argParse argName helpMessage
+   = Opts.argument (argParseToReadM argParse)
+   $ Opts.metavar (Text.unpack (getArgName argName))
   <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
-parameterAuto :: Read a => ParameterName -> Optional HelpMessage -> Parser a
-parameterAuto = parameter (readMaybe . Text.unpack)
+argRead :: Read a => ArgName -> Optional HelpMessage -> Parser a
+argRead = arg (readMaybe . Text.unpack)
 
-parameterText :: ParameterName -> Optional HelpMessage -> Parser Text
-parameterText = parameter Just
+argText :: ArgName -> Optional HelpMessage -> Parser Text
+argText = arg Just
 
-parameterInteger :: ParameterName -> Optional HelpMessage -> Parser Integer
-parameterInteger = parameterAuto
+argInteger :: ArgName -> Optional HelpMessage -> Parser Integer
+argInteger = argRead
 
-parameterInt :: ParameterName -> Optional HelpMessage -> Parser Int
-parameterInt = parameterAuto
+argInt :: ArgName -> Optional HelpMessage -> Parser Int
+argInt = argRead
 
-parameterDouble :: ParameterName -> Optional HelpMessage -> Parser Double
-parameterDouble = parameterAuto
+argDouble :: ArgName -> Optional HelpMessage -> Parser Double
+argDouble = argRead
 
-parameterReadToReadM :: (Text -> Maybe a) -> Opts.ReadM a
-parameterReadToReadM f = do
+argParseToReadM :: (Text -> Maybe a) -> Opts.ReadM a
+argParseToReadM f = do
     s <- Opts.readerAsk
     case f (Text.pack s) of
         Just a -> return a

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -8,7 +8,6 @@ module Turtle.Options
     , parameterRead
     , ParameterName(..)
     , LongName(..)
-    , ShortName(..)
     , HelpMessage(..)
     , options
     , switch
@@ -54,13 +53,12 @@ optionalOr f (Specific a) = f a
 
 switch
     :: LongName
-    -> Optional ShortName
     -> Optional HelpMessage
     -> Parser Bool
-switch longName shortName helpMessage
+switch longName helpMessage
    = Opts.switch
    $ (Opts.long . Text.unpack . getLongName) longName
-  <> optionalOr (Opts.short . getShortName) shortName
+  <> maybe mempty (Opts.short . fst) (Text.uncons (getLongName longName))
   <> optionalOr (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
 parameter

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -59,7 +59,8 @@ Library
         text                          < 1.3,
         time                          < 1.6,
         transformers    >= 0.2.0.0 && < 0.5,
-        optparse-applicative >= 0.11 && < 0.12
+        optparse-applicative >= 0.11 && < 0.12,
+        optional-args   >= 1.0     && < 2.0
     if os(windows)
         Build-Depends: Win32 >= 2.2.0.1 && < 2.4
     else

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -58,7 +58,8 @@ Library
         temporary                     < 1.3,
         text                          < 1.3,
         time                          < 1.6,
-        transformers    >= 0.2.0.0 && < 0.5
+        transformers    >= 0.2.0.0 && < 0.5,
+        optparse-applicative >= 0.11 && < 0.12
     if os(windows)
         Build-Depends: Win32 >= 2.2.0.1 && < 2.4
     else
@@ -68,6 +69,7 @@ Library
         Turtle.Format,
         Turtle.Pattern,
         Turtle.Shell,
+        Turtle.Options,
         Turtle.Prelude,
         Turtle.Tutorial
     GHC-Options: -O2 -Wall


### PR DESCRIPTION
This is a place to discuss the new `Turtle.Options` module. It's meant to be a simplified interface to the `optparse-applicative` library that allows to quickly add options parsing to a script. It's not meant to give fine-grained control or much power over the parsing process, for those purposes the `optparse-applicative` library should be used directly.

This pull request is not meant to be merged until the module is completed.

fixes #13 