### PR TITLE
Rename `du` to `size`

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -123,7 +123,7 @@ module Turtle.Prelude (
     , rm
     , rmdir
     , rmtree
-    , du
+    , size
     , testfile
     , testdir
     , date
@@ -557,9 +557,9 @@ rmdir path = liftIO (Filesystem.removeDirectory path)
 rmtree :: MonadIO io => FilePath -> io ()
 rmtree path = liftIO (Filesystem.removeTree path)
 
--- | Get the size of a file or a directory in kilobytes
-du :: MonadIO io => FilePath -> io Integer
-du path = liftIO (Filesystem.getSize path)
+-- | Get the size of a file or a directory in bytes
+size :: MonadIO io => FilePath -> io Integer
+size path = liftIO (Filesystem.getSize path)
 
 -- | Check if a file exists
 testfile :: MonadIO io => FilePath -> io Bool


### PR DESCRIPTION
Originally `du` returned bytes instead of kilobytes, which I think is more useful. However *Unix du* returns kilobytes. So name change is appropriate.

Alternative option would be to keep name *du*, but change return value into kilobytes.

P.S. I do not know what is up with that  `Renamed 80 ./slides`, my commit msg was different (I am *newb* sorry)