### PR TITLE
Additional changes to options parsing

### DIFF
--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -9,8 +9,8 @@
 -- > import Turtle
 -- >
 -- > parser :: Parser (Text, Int)
--- > parser = (,) <$> argText     "name" "Your first name"
--- >              <*> argIntegral "age"  "Your current age"
+-- > parser = (,) <$> optText     "name" "Your first name"
+-- >              <*> optIntegral "age"  "Your current age"
 -- >
 -- > main = do
 -- >     (name, age) <- options "Greeting script" parser
@@ -24,7 +24,7 @@
 -- > $ ./options --help
 -- > Greeting script
 -- >
--- > Usage: options --name NAME --age AGE
+-- > Usage: options (-n|--name NAME) (-a|--age AGE)
 -- >
 -- > Available options:
 -- >  -h,--help                Show this help text
@@ -38,8 +38,15 @@ module Turtle.Options
     , Description
     , HelpMessage
 
-      -- * Build parsers
+      -- * Flag-based option parsers
     , switch
+    , optText
+    , optIntegral
+    , optFractional
+    , optRead
+    , opt
+
+    -- * Positional argument parsers
     , argText
     , argIntegral
     , argFractional
@@ -73,9 +80,9 @@ options desc parser = liftIO
 
 {-| The name of a command-line argument
 
-    This is used to infer the long name and metavariable for the command line
-    flag.  For example, an `ArgName` of @\"name\"@ will create a @--name@ flag
-    with a @NAME@ metavariable
+    This is used to infer the long name, short name, and metavariable for the
+    command line flag.  For example, an `ArgName` of @\"name\"@ will create a
+    @--name@ flag with a @NAME@ metavariable and a short name of @-n@
 -}
 newtype ArgName = ArgName { getArgName :: Text }
     deriving (IsString)
@@ -104,37 +111,74 @@ switch
 switch argName helpMessage
    = Opts.switch
    $ (Opts.long . Text.unpack . getArgName) argName
+  <> foldMap (Opts.short . fst) (Text.uncons (getArgName argName))
   <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
-{- | Build an argument parser for any type by providing a `Text`-parsing
+{- | Build a flag-based option parser for any type by providing a `Text`-parsing
      function
+-}
+opt :: (Text -> Maybe a)
+    -> ArgName
+    -> Optional HelpMessage
+    -> Parser a
+opt argParse argName helpMessage
+   = Opts.option (argParseToReadM argParse)
+   $ Opts.metavar (Text.unpack (Text.toUpper (getArgName argName)))
+  <> Opts.long (Text.unpack (getArgName argName))
+  <> foldMap (Opts.short . fst) (Text.uncons (getArgName argName))
+  <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
+
+-- | Parse any type that implements `Read`
+optRead :: Read a => ArgName -> Optional HelpMessage -> Parser a
+optRead = opt (readMaybe . Text.unpack)
+
+{-| Parse any type that implements `Integral` as n flag-based option
+
+    This is most commonly used to parse an `Int` or `Integer`
+-}
+optIntegral :: Integral n => ArgName -> Optional HelpMessage -> Parser n
+optIntegral argName helpMessage = fmap fromInteger (optRead argName helpMessage)
+
+-- | Parse a `Text` value as a flag-based option
+optText :: ArgName -> Optional HelpMessage -> Parser Text
+optText = opt Just
+
+{-| Parse any type that implements `Fractional` as a flag-based option
+
+    This is most commonly used to parse a `Double`
+-}
+optFractional :: Fractional n => ArgName -> Optional HelpMessage -> Parser n
+optFractional argName helpMessage =
+    fmap fromRational (optRead argName helpMessage)
+
+{- | Build a positional argument parser for any type by providing a
+    `Text`-parsing function
 -}
 arg :: (Text -> Maybe a)
     -> ArgName
     -> Optional HelpMessage
     -> Parser a
 arg argParse argName helpMessage
-   = Opts.option (argParseToReadM argParse)
+   = Opts.argument (argParseToReadM argParse)
    $ Opts.metavar (Text.unpack (Text.toUpper (getArgName argName)))
-  <> Opts.long (Text.unpack (getArgName argName))
   <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
--- | Parse any type that implements `Read`
+-- | Parse any type that implements `Read` as a positional argument
 argRead :: Read a => ArgName -> Optional HelpMessage -> Parser a
 argRead = arg (readMaybe . Text.unpack)
 
-{-| Parse any type that implements `Integral`
+{-| Parse any type that implements `Integral` as a positional argument
 
     This is most commonly used to parse an `Int` or `Integer`
 -}
 argIntegral :: Integral n => ArgName -> Optional HelpMessage -> Parser n
 argIntegral argName helpMessage = fmap fromInteger (argRead argName helpMessage)
 
--- | Parse a `Text` value
+-- | Parse a `Text` value as a positional argument
 argText :: ArgName -> Optional HelpMessage -> Parser Text
 argText = arg Just
 
-{-| Parse any type that implements `Fractional`
+{-| Parse any type that implements `Fractional` as a positional argument
 
     This is most commonly used to parse a `Double`
 -}

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -1,21 +1,54 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
--- TODO: documentation
+-- | Example usage of this module:
+--
+-- > -- options.hs
+-- >
+-- > {-# LANGUAGE OverloadedStrings #-}
+-- >
+-- > import Turtle
+-- >
+-- > parser :: Parser (Text, Int)
+-- > parser = (,) <$> argText     "name" "Your first name"
+-- >              <*> argIntegral "age"  "Your current age"
+-- >
+-- > main = do
+-- >     (name, age) <- options "Greeting script" parser
+-- >     echo (format ("Hello there, "%s) name)
+-- >     echo (format ("You are "%d%" years old") age)
+--
+-- > $ ./options --name John --age 42
+-- > Hello there, John
+-- > You are 42 years old
+--
+-- > $ ./options --help
+-- > Greeting script
+-- >
+-- > Usage: options --name NAME --age AGE
+-- >
+-- > Available options:
+-- >  -h,--help                Show this help text
+-- >  --name NAME              Your first name
+-- >  --age AGE                Your current age
 
 module Turtle.Options
-    ( Parser
-    , ArgName(..)
-    , LongName(..)
-    , HelpMessage(..)
-    , options
+    ( -- * Types
+      Parser
+    , ArgName
+    , Description
+    , HelpMessage
+
+      -- * Build parsers
     , switch
-    , arg
-    , argRead
-    , argIntegral
     , argText
-    , argInteger
-    , argInt
-    , argDouble
+    , argIntegral
+    , argFractional
+    , argRead
+    , arg
+
+      -- * Consume parsers
+    , options
+
     ) where
 
 import Data.Monoid
@@ -31,56 +64,83 @@ import Options.Applicative (Parser)
 import qualified Options.Applicative as Opts
 import qualified Options.Applicative.Types as Opts
 
-options :: MonadIO io => Text -> Parser a -> io a
-options header parser = liftIO
+-- | Parse the given options from the command line
+options :: MonadIO io => Description -> Parser a -> io a
+options desc parser = liftIO
     $ Opts.execParser
-    $ Opts.info (Opts.helper <*> parser) (Opts.header (Text.unpack header))
+    $ Opts.info (Opts.helper <*> parser)
+                (Opts.header (Text.unpack (getDescription desc)))
 
+{-| The name of a command-line argument
+
+    This is used to infer the long name and metavariable for the command line
+    flag.  For example, an `ArgName` of @\"name\"@ will create a @--name@ flag
+    with a @NAME@ metavariable
+-}
 newtype ArgName = ArgName { getArgName :: Text }
     deriving (IsString)
 
-newtype LongName = LongName { getLongName :: Text }
+{-| A brief description of what your program does
+
+    This description will appear in the header of the @--help@ output
+-}
+newtype Description = Description { getDescription :: Text }
     deriving (IsString)
 
+{-| A helpful message explaining what a flag does
+
+    This will appear in the @--help@ output
+-}
 newtype HelpMessage = HelpMessage { getHelpMessage :: Text }
     deriving (IsString)
 
+{-| This parser returns `True` if the given flag is set and `False` if the
+    flag is absent
+-}
 switch
-    :: LongName
+    :: ArgName
     -> Optional HelpMessage
     -> Parser Bool
-switch longName helpMessage
+switch argName helpMessage
    = Opts.switch
-   $ (Opts.long . Text.unpack . getLongName) longName
-  <> foldMap (Opts.short . fst) (Text.uncons (getLongName longName))
+   $ (Opts.long . Text.unpack . getArgName) argName
   <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
+{- | Build an argument parser for any type by providing a `Text`-parsing
+     function
+-}
 arg :: (Text -> Maybe a)
     -> ArgName
     -> Optional HelpMessage
     -> Parser a
 arg argParse argName helpMessage
-   = Opts.argument (argParseToReadM argParse)
-   $ Opts.metavar (Text.unpack (getArgName argName))
+   = Opts.option (argParseToReadM argParse)
+   $ Opts.metavar (Text.unpack (Text.toUpper (getArgName argName)))
+  <> Opts.long (Text.unpack (getArgName argName))
   <> foldMap (Opts.help . Text.unpack . getHelpMessage) helpMessage
 
+-- | Parse any type that implements `Read`
 argRead :: Read a => ArgName -> Optional HelpMessage -> Parser a
 argRead = arg (readMaybe . Text.unpack)
 
-argIntegral :: Integral a => ArgName -> Optional HelpMessage -> Parser a
+{-| Parse any type that implements `Integral`
+
+    This is most commonly used to parse an `Int` or `Integer`
+-}
+argIntegral :: Integral n => ArgName -> Optional HelpMessage -> Parser n
 argIntegral argName helpMessage = fmap fromInteger (argRead argName helpMessage)
 
+-- | Parse a `Text` value
 argText :: ArgName -> Optional HelpMessage -> Parser Text
 argText = arg Just
 
-argInteger :: ArgName -> Optional HelpMessage -> Parser Integer
-argInteger = argRead
+{-| Parse any type that implements `Fractional`
 
-argInt :: ArgName -> Optional HelpMessage -> Parser Int
-argInt = argRead
-
-argDouble :: ArgName -> Optional HelpMessage -> Parser Double
-argDouble = argRead
+    This is most commonly used to parse a `Double`
+-}
+argFractional :: Fractional n => ArgName -> Optional HelpMessage -> Parser n
+argFractional argName helpMessage =
+    fmap fromRational (argRead argName helpMessage)
 
 argParseToReadM :: (Text -> Maybe a) -> Opts.ReadM a
 argParseToReadM f = do

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -48,7 +48,7 @@ Library
     Build-Depends:
         base            >= 4.5     && < 5  ,
         async           >= 2.0.0.0 && < 2.1,
-        clock           >= 0.4.1.2 && < 0.5,
+        clock           >= 0.4.1.2 && < 0.6,
         directory                     < 1.3,
         foldl                         < 1.2,
         managed                       < 1.1,


### PR DESCRIPTION
@int-index: Could you take a look at these changes?  The main differences are:

* I generalized `argDouble` to `argFractional`
* I merged `argInt`/`argInteger`/`argIntegral` into `argIntegral`
* I changed the argument parsing to use flag-based options instead of positional arguments
* I removed short flag names to avoid clashes (it seems like these clashes would be frequent)