### PR TITLE
`sed` now errors if passed a pattern matching the empty string

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -958,11 +958,15 @@ grep pattern s = do
 -}
 sed :: Pattern Text -> Shell Text -> Shell Text
 sed pattern s = do
+    when (matchesEmpty pattern) (die message)
     let pattern' = fmap Text.concat
             (many (pattern <|> fmap Text.singleton anyChar))
     txt    <- s
     txt':_ <- return (match pattern' txt)
     return txt'
+  where
+    message = "sed: the given pattern matches the empty string"
+    matchesEmpty = not . null . flip match ""
 
 -- | Search a directory recursively for all files matching the given `Pattern`
 find :: Pattern a -> FilePath -> Shell FilePath


### PR DESCRIPTION
Fixes #96

Unfortunately, this does not completely fix the problem. `match` is not sufficiently lazy, so `matchesEmpty` diverges if called with e.g. `many ""`.

A more complete solution would either change `match` to be sufficiently lazy or (even better) to keep track of which patterns match the empty string as part of the `Pattern` type and either error or short circuit in cases like `many ""`.