### PR TITLE
Silence a few compiler warnings

### DIFF
--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -67,7 +67,7 @@ import Control.Category (Category(..))
 import Data.Monoid ((<>))
 import Data.String (IsString(..))
 import Data.Text (Text, pack)
-import Data.Word (Word)
+import Data.Word
 import Filesystem.Path.CurrentOS (FilePath, toText)
 import Numeric (showEFloat, showFFloat, showGFloat, showHex, showOct)
 import Prelude hiding ((.), id, FilePath)

--- a/src/Turtle/Pattern.hs
+++ b/src/Turtle/Pattern.hs
@@ -113,10 +113,11 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State
 import Data.Char
 import Data.List (foldl')
-import Data.Monoid (Monoid(..), (<>))
+import Data.Monoid
 import Data.String (IsString(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Prelude -- Fix redundant import warnings
 
 -- | A fully backtracking pattern that parses an @\'a\'@ from some `Text`
 newtype Pattern a = Pattern { runPattern :: StateT Text [] a }

--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -212,7 +212,7 @@ module Turtle.Prelude (
     , tebibytes
     ) where
 
-import Control.Applicative (Alternative(..), (<*), (*>))
+import Control.Applicative
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, withAsync, wait, concurrently)
 import Control.Concurrent.MVar (newMVar, modifyMVar_)
@@ -229,7 +229,7 @@ import Data.Bits ((.&.))
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text, pack, unpack)
 import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
-import Data.Traversable (traverse)
+import Data.Traversable
 import qualified Data.Text    as Text
 import qualified Data.Text.IO as Text
 import qualified Filesystem
@@ -1083,8 +1083,8 @@ paste sA sB = Shell _foldIOAB
             withAsync (foldIO sB foldB) (\asyncB -> do
                 let loop x = do
                         y <- STM.atomically (do
-                            x <- STM.readTVar tvar
-                            case x of
+                            z <- STM.readTVar tvar
+                            case z of
                                 HasAB a b -> do
                                     STM.writeTVar tvar Empty
                                     return (Just (a, b))

--- a/src/Turtle/Shell.hs
+++ b/src/Turtle/Shell.hs
@@ -70,14 +70,15 @@ module Turtle.Shell (
     , using
     ) where
 
-import Control.Applicative (Applicative(..), Alternative(..), liftA2)
+import Control.Applicative
 import Control.Monad (MonadPlus(..), ap)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Managed (Managed, with)
 import Control.Foldl (Fold(..), FoldM(..))
 import qualified Control.Foldl as Foldl
-import Data.Monoid (Monoid(..), (<>))
+import Data.Monoid
 import Data.String (IsString(..))
+import Prelude -- Fix redundant import warnings
 
 -- | A @(Shell a)@ is a protected stream of @a@'s with side effects
 newtype Shell a = Shell { _foldIO :: forall r . FoldM IO a r -> IO r }


### PR DESCRIPTION
Most warnings were "redundant import" warnings due to the inclusion
of Applicative and Monoid in the Prelude of base-4.8.*.