### PR TITLE
Fixed typo in type signature in the tutorial

### DIFF
--- a/src/Turtle/Tutorial.hs
+++ b/src/Turtle/Tutorial.hs
@@ -770,7 +770,7 @@ import Turtle
 -- @
 -- `proc`
 --     :: Text         -- Program
---     :: [Text]       -- Arguments
+--     -> [Text]       -- Arguments
 --     -> Shell Text   -- Standard input (as lines of \`Text\`)
 --     -> IO ExitCode  -- Exit code of the shell command
 -- @


### PR DESCRIPTION
Is this actually an typo? (My haskell is not so great)