### PR TITLE
relax process upper bound

### DIFF
--- a/turtle.cabal
+++ b/turtle.cabal
@@ -53,7 +53,7 @@ Library
         foldl                >= 1.1     && < 1.2,
         hostname                           < 1.1,
         managed                            < 1.1,
-        process              >= 1.0.1.1 && < 1.3,
+        process              >= 1.0.1.1 && < 1.5,
         system-filepath      >= 0.3.1   && < 0.5,
         system-fileio        >= 0.2.1   && < 0.4,
         stm                                < 2.5,


### PR DESCRIPTION
I need process-1.4.2.0 for the [NoStream](https://hackage.haskell.org/package/process-1.4.2.0/docs/System-Process.html#t:StdStream). I tested things and it works fine.