### PR TITLE
Create copymod function to copy file permissions

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -206,6 +206,7 @@ module Turtle.Prelude (
     , chmod
     , getmod
     , setmod
+    , copymod
     , readable, nonreadable
     , writable, nonwritable
     , executable, nonexecutable
@@ -971,6 +972,13 @@ setmod :: MonadIO io => Permissions -> FilePath -> io ()
 setmod permissions path = liftIO (do
     let path' = deslash (Filesystem.encodeString path)
     Directory.setPermissions path' permissions )
+
+-- | Copy a file or directory's permissions (analogous to @chmod --reference@)
+copymod :: MonadIO io => FilePath -> FilePath -> io ()
+copymod sourcePath targetPath = liftIO (do
+    let sourcePath' = deslash (Filesystem.encodeString sourcePath)
+        targetPath' = deslash (Filesystem.encodeString targetPath)
+    Directory.copyPermissions sourcePath' targetPath' )
 
 -- | @+r@
 readable :: Permissions -> Permissions

--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1291,6 +1291,7 @@ inplace pattern file = liftIO (runManaged (do
     (tmpfile, handle) <- mktemp here "turtle"
     outhandle handle (sed pattern (input file))
     liftIO (hClose handle)
+    copymod file tmpfile
     mv tmpfile file ))
 
 


### PR DESCRIPTION
copymod is analogous to `chmod --reference` or `chown --reference`

Fixes #147 