### PR TITLE
Add a grep specific to FilePath

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1260,6 +1260,14 @@ grep pattern s = do
     _:_ <- return (match pattern txt)
     return txt
 
+-- | Keep all files that match the given `Pattern`
+fpgrep :: Pattern a -> Shell FilePath -> Shell FilePath
+fpgrep pattern s = do
+  fpath <- s
+  _:_ <- return (match pattern (either id id (toText fpath)))
+  return fpath
+
+
 {-| Replace all occurrences of a `Pattern` with its `Text` result
 
     `sed` performs substitution on a line-by-line basis, meaning that

--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -173,6 +173,7 @@ module Turtle.Prelude (
     , lstree
     , cat
     , grep
+    , fpgrep
     , sed
     , inplace
     , find
@@ -1264,7 +1265,8 @@ grep pattern s = do
 fpgrep :: Pattern a -> Shell FilePath -> Shell FilePath
 fpgrep pattern s = do
   fpath <- s
-  _:_ <- return (match pattern (either id id (toText fpath)))
+  _:_ <- return (match pattern
+                 (either id id (Filesystem.toText fpath)))
   return fpath
 
 


### PR DESCRIPTION
Don't you think it would be a nice idea to propose this function directly?
And may be to provide an example in the tutorial?

Typically in shell when you are doing `**/*` it won't match files and directories which start by a `.`:

~~~ {.haskell}
allFiles <- fpgrep (invert (prefix "./.")) (find (has ".hs") ".")
~~~

Best.