### PR TITLE
turtle.cabal: allow transformers-0.5 and time-1.6 (come with ghc-8.0.1)

### DIFF
--- a/turtle.cabal
+++ b/turtle.cabal
@@ -59,8 +59,8 @@ Library
         stm                                < 2.5,
         temporary                          < 1.3,
         text                               < 1.3,
-        time                               < 1.6,
-        transformers         >= 0.2.0.0 && < 0.5,
+        time                               < 1.7,
+        transformers         >= 0.2.0.0 && < 0.6,
         optparse-applicative >= 0.11    && < 0.13,
         optional-args        >= 1.0     && < 2.0
     if os(windows)


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>