### PR TITLE
Fixed documentation syntax error.

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1269,7 +1269,7 @@ grep pattern s = do
     `sed` performs substitution on a line-by-line basis, meaning that
     substitutions may not span multiple lines.  Additionally, substitutions may
     occur multiple times within the same line, like the behavior of
-    @s/.../.../g@.
+    @s\/...\/...\/g@.
 
     Warning: Do not use a `Pattern` that matches the empty string, since it will
     match an infinite number of times.  `sed` tries to detect such `Pattern`s


### PR DESCRIPTION
"/" is a special character and it was making the dots...italic.