### PR TITLE
One-line text newtype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 .cabal-sandbox
 cabal.sandbox.config
 .stack-work
+tags

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Turtle v1.2.8
+# Turtle v1.3.0
 
 Turtle is a reimplementation of the Unix command line environment in Haskell so
 that you can use Haskell as a scripting language or a shell.  Think of `turtle`

--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -70,6 +70,7 @@ module Turtle (
     , module Turtle.Pattern
     , module Turtle.Options
     , module Turtle.Shell
+    , module Turtle.Line
     , module Turtle.Prelude
     , module Control.Applicative
     , module Control.Monad
@@ -92,6 +93,7 @@ import Turtle.Format
 import Turtle.Pattern
 import Turtle.Options
 import Turtle.Shell
+import Turtle.Line
 import Turtle.Prelude
 import Control.Applicative
     ( Applicative(..)

--- a/src/Turtle/Line.hs
+++ b/src/Turtle/Line.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Turtle.Line
+  ( Line
+  , lineToText
+  , textToLines
+  , linesToText
+  , textToLine
+  , unsafeTextToLine
+  , NewlineForbidden(..)
+  ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Coerce
+#endif
+import Data.String
+#if __GLASGOW_HASKELL__ >= 710
+#else
+import Data.Monoid
+#endif
+import Data.Maybe
+import Data.Typeable
+import Control.Exception
+
+-- | The `NewlineForbidden` exception is thrown when you construct a `Line`
+-- using an overloaded string literal or by calling `fromString` explicitly
+-- and the supplied string contains newlines. This is a programming error to
+-- do so: if you aren't sure that the input string is newline-free, do not
+-- rely on the @`IsString` `Line`@ instance.
+--
+-- When debugging, it might be useful to look for implicit invocations of
+-- `fromString` for `Line`:
+--
+-- >>> sh (do { line <- "Hello\nWorld"; echo line })
+-- *** Exception: NewlineForbidden
+--
+-- In the above example, `echo` expects its argument to be a `Line`, thus
+-- @line :: `Line`@. Since we bind @line@ in `Shell`, the string literal
+-- @\"Hello\\nWorld\"@ has type @`Shell` `Line`@. The
+-- @`IsString` (`Shell` `Line`)@ instance delegates the construction of a
+-- `Line` to the @`IsString` `Line`@ instance, where the exception is thrown.
+--
+-- To fix the problem, use `textToLines`:
+--
+-- >>> sh (do { line <- select (textToLines "Hello\nWorld"); echo line })
+-- Hello
+-- World
+data NewlineForbidden = NewlineForbidden
+  deriving (Show, Typeable)
+
+instance Exception NewlineForbidden
+
+-- | A line of text (does not contain newlines).
+newtype Line = Line Text
+  deriving (Eq, Ord, Show, Monoid)
+
+instance IsString Line where
+  fromString = fromMaybe (throw NewlineForbidden) . textToLine . fromString
+
+-- | Convert a line to a text value.
+lineToText :: Line -> Text
+lineToText (Line t) = t
+
+-- | Split text into lines. The inverse of `linesToText`.
+textToLines :: Text -> [Line]
+textToLines =
+#if __GLASGOW_HASKELL__ >= 708
+  coerce Text.lines
+#else
+  map unsafeTextToLine . Text.lines
+#endif
+
+-- | Merge lines into a single text value.
+linesToText :: [Line] -> Text
+linesToText =
+#if __GLASGOW_HASKELL__ >= 708
+  coerce Text.unlines
+#else
+  Text.unlines . map lineToText
+#endif
+
+-- | Try to convert a text value into a line.
+-- Precondition (checked): the argument does not contain newlines.
+textToLine :: Text -> Maybe Line
+textToLine = fromSingleton . textToLines
+  where
+    fromSingleton [a] = Just a
+    fromSingleton _   = Nothing
+
+-- | Convert a text value into a line.
+-- Precondition (unchecked): the argument does not contain newlines.
+unsafeTextToLine :: Text -> Line
+unsafeTextToLine = Line

--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -318,6 +318,7 @@ import Prelude hiding (FilePath)
 import Turtle.Pattern (Pattern, anyChar, chars, match, selfless, sepBy)
 import Turtle.Shell
 import Turtle.Format (Format, format, makeFormat, d, w, (%))
+import Turtle.Line
 
 {-| Run a command using @execvp@, retrieving the exit code
 
@@ -329,7 +330,7 @@ proc
     -- ^ Command
     -> [Text]
     -- ^ Arguments
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io ExitCode
     -- ^ Exit code
@@ -352,7 +353,7 @@ shell
     :: MonadIO io
     => Text
     -- ^ Command line
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io ExitCode
     -- ^ Exit code
@@ -381,7 +382,7 @@ procs
     -- ^ Command
     -> [Text]
     -- ^ Arguments
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io ()
 procs cmd args s = do
@@ -404,7 +405,7 @@ shells
     :: MonadIO io
     => Text
     -- ^ Command line
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io ()
     -- ^ Exit code
@@ -425,7 +426,7 @@ procStrict
     -- ^ Command
     -> [Text]
     -- ^ Arguments
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io (ExitCode, Text)
     -- ^ Exit code and stdout
@@ -444,7 +445,7 @@ shellStrict
     :: MonadIO io
     => Text
     -- ^ Command line
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io (ExitCode, Text)
     -- ^ Exit code and stdout
@@ -459,7 +460,7 @@ procStrictWithErr
     -- ^ Command
     -> [Text]
     -- ^ Arguments
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io (ExitCode, Text, Text)
     -- ^ (Exit code, stdout, stderr)
@@ -476,7 +477,7 @@ shellStrictWithErr
     :: MonadIO io
     => Text
     -- ^ Command line
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io (ExitCode, Text, Text)
     -- ^ (Exit code, stdout, stderr)
@@ -491,7 +492,7 @@ system
     :: MonadIO io
     => Process.CreateProcess
     -- ^ Command
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io ExitCode
     -- ^ Exit code
@@ -519,8 +520,8 @@ system p s = liftIO (do
             let feedIn :: (forall a. IO a -> IO a) -> IO ()
                 feedIn restore =
                     restore (sh (do
-                        txt <- s
-                        liftIO (Text.hPutStrLn hIn txt) ) )
+                        line <- s
+                        liftIO (Text.hPutStrLn hIn (lineToText line)) ) )
                     `finally` close hIn
             mask_ (withAsyncWithUnmask feedIn (\a -> Process.waitForProcess ph <* wait a) )
         handle (Nothing , ph) = do
@@ -532,7 +533,7 @@ systemStrict
     :: MonadIO io
     => Process.CreateProcess
     -- ^ Command
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io (ExitCode, Text)
     -- ^ Exit code and stdout
@@ -559,8 +560,8 @@ systemStrict p s = liftIO (do
         let feedIn :: (forall a. IO a -> IO a) -> IO ()
             feedIn restore =
                 restore (sh (do
-                    txt <- s
-                    liftIO (Text.hPutStrLn hIn txt) ) )
+                    line <- s
+                    liftIO (Text.hPutStrLn hIn (lineToText line)) ) )
                 `finally` close hIn
 
         concurrently
@@ -571,7 +572,7 @@ systemStrictWithErr
     :: MonadIO io
     => Process.CreateProcess
     -- ^ Command
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
     -> io (ExitCode, Text, Text)
     -- ^ Exit code and stdout
@@ -598,8 +599,8 @@ systemStrictWithErr p s = liftIO (do
         let feedIn :: (forall a. IO a -> IO a) -> IO ()
             feedIn restore =
                 restore (sh (do
-                    txt <- s
-                    liftIO (Text.hPutStrLn hIn txt) ) )
+                    line <- s
+                    liftIO (Text.hPutStrLn hIn (lineToText line)) ) )
                 `finally` close hIn
 
         runConcurrently $ (,,)
@@ -616,9 +617,9 @@ inproc
     -- ^ Command
     -> [Text]
     -- ^ Arguments
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard output
 inproc cmd args = stream (Process.proc (unpack cmd) (map unpack args))
 
@@ -632,18 +633,18 @@ inproc cmd args = stream (Process.proc (unpack cmd) (map unpack args))
 inshell
     :: Text
     -- ^ Command line
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard output
 inshell cmd = stream (Process.shell (unpack cmd))
 
 stream
     :: Process.CreateProcess
     -- ^ Command
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard output
 stream p s = do
     let p' = p
@@ -668,8 +669,8 @@ stream p s = do
     let feedIn :: (forall a. IO a -> IO a) -> IO ()
         feedIn restore =
             restore (sh (do
-                txt <- s
-                liftIO (Text.hPutStrLn hIn txt) ) )
+                line <- s
+                liftIO (Text.hPutStrLn hIn (lineToText line)) ) )
             `finally` close hIn
 
     a <- using (managed (mask_ . withAsyncWithUnmask feedIn))
@@ -678,9 +679,9 @@ stream p s = do
 streamWithErr
     :: Process.CreateProcess
     -- ^ Command
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
-    -> Shell (Either Text Text)
+    -> Shell (Either Line Line)
     -- ^ Lines of standard output
 streamWithErr p s = do
     let p' = p
@@ -705,22 +706,22 @@ streamWithErr p s = do
     let feedIn :: (forall a. IO a -> IO a) -> IO ()
         feedIn restore =
             restore (sh (do
-                txt <- s
-                liftIO (Text.hPutStrLn hIn txt) ) )
+                line <- s
+                liftIO (Text.hPutStrLn hIn (lineToText line)) ) )
             `finally` close hIn
 
     queue <- liftIO TQueue.newTQueueIO
     let forwardOut :: (forall a. IO a -> IO a) -> IO ()
         forwardOut restore =
             restore (sh (do
-                txt <- inhandle hOut
-                liftIO (STM.atomically (TQueue.writeTQueue queue (Just (Right txt)))) ))
+                line <- inhandle hOut
+                liftIO (STM.atomically (TQueue.writeTQueue queue (Just (Right line)))) ))
             `finally` STM.atomically (TQueue.writeTQueue queue Nothing)
     let forwardErr :: (forall a. IO a -> IO a) -> IO ()
         forwardErr restore =
             restore (sh (do
-                txt <- inhandle hErr
-                liftIO (STM.atomically (TQueue.writeTQueue queue (Just (Left  txt)))) ))
+                line <- inhandle hErr
+                liftIO (STM.atomically (TQueue.writeTQueue queue (Just (Left  line)))) ))
             `finally` STM.atomically (TQueue.writeTQueue queue Nothing)
     let drain = Shell (\(FoldM step begin done) -> do
             x0 <- begin
@@ -756,9 +757,9 @@ inprocWithErr
     -- ^ Command
     -> [Text]
     -- ^ Arguments
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
-    -> Shell (Either Text Text)
+    -> Shell (Either Line Line)
     -- ^ Lines of either standard output (`Right`) or standard error (`Left`)
 inprocWithErr cmd args =
     streamWithErr (Process.proc (unpack cmd) (map unpack args))
@@ -775,30 +776,30 @@ inprocWithErr cmd args =
 inshellWithErr
     :: Text
     -- ^ Command line
-    -> Shell Text
+    -> Shell Line
     -- ^ Lines of standard input
-    -> Shell (Either Text Text)
+    -> Shell (Either Line Line)
     -- ^ Lines of either standard output (`Right`) or standard error (`Left`)
 inshellWithErr cmd = streamWithErr (Process.shell (unpack cmd))
 
 -- | Print to @stdout@
-echo :: MonadIO io => Text -> io ()
-echo txt = liftIO (Text.putStrLn txt)
+echo :: MonadIO io => Line -> io ()
+echo line = liftIO (Text.putStrLn (lineToText line))
 
 -- | Print to @stderr@
-err :: MonadIO io => Text -> io ()
-err txt = liftIO (Text.hPutStrLn IO.stderr txt)
+err :: MonadIO io => Line -> io ()
+err line = liftIO (Text.hPutStrLn IO.stderr (lineToText line))
 
 {-| Read in a line from @stdin@
 
     Returns `Nothing` if at end of input
 -}
-readline :: MonadIO io => io (Maybe Text)
+readline :: MonadIO io => io (Maybe Line)
 readline = liftIO (do
     eof <- IO.isEOF
     if eof
         then return Nothing
-        else fmap (Just . pack) getLine )
+        else fmap (Just . unsafeTextToLine . pack) getLine )
 
 -- | Get command line arguments in a list
 arguments :: MonadIO io => io [Text]
@@ -1321,17 +1322,17 @@ wait :: MonadIO io => Async a -> io a
 wait a = liftIO (Control.Concurrent.Async.wait a)
 
 -- | Read lines of `Text` from standard input
-stdin :: Shell Text
+stdin :: Shell Line
 stdin = inhandle IO.stdin
 
 -- | Read lines of `Text` from a file
-input :: FilePath -> Shell Text
+input :: FilePath -> Shell Line
 input file = do
     handle <- using (readonly file)
     inhandle handle
 
 -- | Read lines of `Text` from a `Handle`
-inhandle :: Handle -> Shell Text
+inhandle :: Handle -> Shell Line
 inhandle handle = Shell (\(FoldM step begin done) -> do
     x0 <- begin
     let loop x = do
@@ -1340,45 +1341,45 @@ inhandle handle = Shell (\(FoldM step begin done) -> do
                 then done x
                 else do
                     txt <- Text.hGetLine handle
-                    x'  <- step x txt
+                    x'  <- step x (unsafeTextToLine txt)
                     loop $! x'
     loop $! x0 )
 
 -- | Stream lines of `Text` to standard output
-stdout :: MonadIO io => Shell Text -> io ()
+stdout :: MonadIO io => Shell Line -> io ()
 stdout s = sh (do
-    txt <- s
-    liftIO (echo txt) )
+    line <- s
+    liftIO (echo line) )
 
 -- | Stream lines of `Text` to a file
-output :: MonadIO io => FilePath -> Shell Text -> io ()
+output :: MonadIO io => FilePath -> Shell Line -> io ()
 output file s = sh (do
     handle <- using (writeonly file)
-    txt    <- s
-    liftIO (Text.hPutStrLn handle txt) )
+    line   <- s
+    liftIO (Text.hPutStrLn handle (lineToText line)) )
 
 -- | Stream lines of `Text` to a `Handle`
-outhandle :: MonadIO io => Handle -> Shell Text -> io ()
+outhandle :: MonadIO io => Handle -> Shell Line -> io ()
 outhandle handle s = sh (do
-    txt <- s
-    liftIO (Text.hPutStrLn handle txt) )
+    line <- s
+    liftIO (Text.hPutStrLn handle (lineToText line)) )
 
 -- | Stream lines of `Text` to append to a file
-append :: MonadIO io => FilePath -> Shell Text -> io ()
+append :: MonadIO io => FilePath -> Shell Line -> io ()
 append file s = sh (do
     handle <- using (appendonly file)
-    txt    <- s
-    liftIO (Text.hPutStrLn handle txt) )
+    line   <- s
+    liftIO (Text.hPutStrLn handle (lineToText line)) )
 
 -- | Stream lines of `Text` to standard error
-stderr :: MonadIO io => Shell Text -> io ()
+stderr :: MonadIO io => Shell Line -> io ()
 stderr s = sh (do
-    txt <- s
-    liftIO (err txt) )
+    line <- s
+    liftIO (err line) )
 
 -- | Read in a stream's contents strictly
-strict :: MonadIO io => Shell Text -> io Text
-strict s = liftM Text.unlines (fold s list)
+strict :: MonadIO io => Shell Line -> io Text
+strict s = liftM linesToText (fold s list)
 
 -- | Acquire a `Managed` read-only `Handle` from a `FilePath`
 readonly :: MonadManaged managed => FilePath -> managed Handle
@@ -1397,11 +1398,11 @@ cat :: [Shell a] -> Shell a
 cat = msum
 
 -- | Keep all lines that match the given `Pattern`
-grep :: Pattern a -> Shell Text -> Shell Text
+grep :: Pattern a -> Shell Line -> Shell Line
 grep pattern s = do
-    txt <- s
-    _:_ <- return (match pattern txt)
-    return txt
+    line <- s
+    _:_ <- return (match pattern (lineToText line))
+    return line
 
 {-| Replace all occurrences of a `Pattern` with its `Text` result
 
@@ -1415,14 +1416,14 @@ grep pattern s = do
     and `die` with an error message if they occur, but this detection is
     necessarily incomplete.
 -}
-sed :: Pattern Text -> Shell Text -> Shell Text
+sed :: Pattern Text -> Shell Line -> Shell Line
 sed pattern s = do
     when (matchesEmpty pattern) (die message)
     let pattern' = fmap Text.concat
             (many (pattern <|> fmap Text.singleton anyChar))
-    txt    <- s
-    txt':_ <- return (match pattern' txt)
-    return txt'
+    line   <- s
+    txt':_ <- return (match pattern' (lineToText line))
+    select (textToLines txt')
   where
     message = "sed: the given pattern matches the empty string"
     matchesEmpty = not . null . flip match ""
@@ -1447,7 +1448,7 @@ find pattern dir = do
     return path
 
 -- | A Stream of @\"y\"@s
-yes :: Shell Text
+yes :: Shell Line
 yes = fmap (\_ -> "y") endless
 
 -- | Number each element of a `Shell` (starting at 0)
@@ -1577,8 +1578,8 @@ limitWhile predicate s = Shell (\(FoldM step begin done) -> do
 cache :: (Read a, Show a) => FilePath -> Shell a -> Shell a
 cache file s = do
     let cached = do
-            txt <- input file
-            case reads (Text.unpack txt) of
+            line <- input file
+            case reads (Text.unpack (lineToText line)) of
                 [(ma, "")] -> return ma
                 _          ->
                     die (format ("cache: Invalid data stored in "%w) file)
@@ -1707,8 +1708,10 @@ tebibytes = (`div` 1024) . gibibytes
     This uses the convention that the elements of the stream are implicitly
     ended by newlines that are one character wide
 -}
-countChars :: Integral n => Fold Text n
-countChars = Control.Foldl.Text.length + charsPerNewline * countLines
+countChars :: Integral n => Fold Line n
+countChars =
+  premap lineToText Control.Foldl.Text.length +
+    charsPerNewline * countLines
 
 charsPerNewline :: Num a => a
 #ifdef mingw32_HOST_OS
@@ -1718,15 +1721,15 @@ charsPerNewline = 1
 #endif
 
 -- | Count the number of words in the stream (like @wc -w@)
-countWords :: Integral n => Fold Text n
-countWords = premap Text.words (handles traverse genericLength)
+countWords :: Integral n => Fold Line n
+countWords = premap (Text.words . lineToText) (handles traverse genericLength)
 
 {-| Count the number of lines in the stream (like @wc -l@)
 
     This uses the convention that each element of the stream represents one
     line
 -}
-countLines :: Integral n => Fold Text n
+countLines :: Integral n => Fold Line n
 countLines = genericLength
 
 -- | Get the status of a file

--- a/src/Turtle/Tutorial.hs
+++ b/src/Turtle/Tutorial.hs
@@ -374,7 +374,7 @@ import Turtle
 -- > $ ./example.hs
 -- > 
 -- > example.hs:8:10:
--- >     Couldn't match expected type `Text' with actual type `UTCTime'
+-- >     Couldn't match expected type `Line' with actual type `UTCTime'
 -- >     In the first argument of `echo', namely `time'
 -- >     In a stmt of a 'do' block: echo time
 -- >     In the expression:
@@ -383,13 +383,14 @@ import Turtle
 -- >            echo time }
 --
 -- The error points to the last line of our program: @(example.hs:8:10)@ means
--- line 8, column 10 of our program.  If you study the error message closely
--- you'll see that the `echo` function expects a `Text` value, but we passed it
--- @\'time\'@, which was a `UTCTime` value.  Although the error is at the end of
--- our script, Haskell catches this error before even running the script.  When
--- we \"interpret\" a Haskell script the Haskell compiler actually compiles the
--- script without any optimizations to generate a temporary executable and then
--- runs the executable, much like Perl does for Perl scripts.
+-- line 8, column 10 of our program. If you study the error message closely
+-- you'll see that the `echo` function expects a `Line` value (a piece of text
+-- without newlines), but we passed it @\'time\'@, which was a `UTCTime` value.
+-- Although the error is at the end of our script, Haskell catches this error
+-- before even running the script.  When we \"interpret\" a Haskell script the
+-- Haskell compiler actually compiles the script without any optimizations to
+-- generate a temporary executable and then runs the executable, much like Perl
+-- does for Perl scripts.
 --
 -- You might wonder: \"where are the types?\"  None of the above programs had
 -- any type signatures or type annotations, yet the compiler still detected type
@@ -591,8 +592,8 @@ import Turtle
 -- > --      v  v
 -- > main :: IO ()
 --
--- Not every top-level value has to be a subroutine, though.  For example, you
--- can define unadorned `Text` values at the top-level, as we saw previously:
+-- Not every top-level value has to be a subroutine, though. For example, you
+-- can define unadorned `Line` values at the top-level, as we saw previously:
 --
 -- > #!/usr/bin/env stack
 -- > -- stack --install-ghc runghc --package turtle
@@ -601,7 +602,7 @@ import Turtle
 -- > 
 -- > import Turtle
 -- > 
--- > str :: Text
+-- > str :: Line
 -- > str = "Hello!"
 -- > 
 -- > main :: IO ()
@@ -639,21 +640,21 @@ import Turtle
 -- >     In an equation for `str': str = "Hello, world!"
 -- > 
 -- > example.hs:11:13:
--- >     Couldn't match expected type `Text' with actual type `Int'
+-- >     Couldn't match expected type `Line' with actual type `Int'
 -- >     In the first argument of `echo', namely `str'
 -- >     In the expression: echo str
 -- >     In an equation for `main': main = echo str
 --
 -- The first error message relates to the @OverloadedStrings@ extensions. When
 -- we enable @OverloadedStrings@ the compiler overloads string literals,
--- interpreting them as any type that implements the `IsString` interface.  The
+-- interpreting them as any type that implements the `IsString` interface. The
 -- error message says that `Int` does not implement the `IsString` interface so
 -- the compiler cannot interpret a string literal as an `Int`.  On the other
--- hand the `Text` and `Turtle.FilePath` types do implement `IsString`, which
--- is why we can interpret string literals as `Text` or `Turtle.FilePath`
--- values.
+-- hand the `Text`, `Line` and `Turtle.FilePath` types do implement `IsString`,
+-- which is why we can interpret string literals as `Text`, `Line` or
+-- `Turtle.FilePath` values.
 --
--- The second error message says that `echo` expects a `Text` value, but we
+-- The second error message says that `echo` expects a `Line` value, but we
 -- declared @str@ to be an `Int`, so the compiler aborts compilation, requiring
 -- us to either fix or delete our type signature.
 --
@@ -673,7 +674,7 @@ import Turtle
 -- > 
 -- > import Turtle
 -- > 
--- > str :: Text
+-- > str :: Line
 -- > str = 4
 -- > 
 -- > main :: IO ()
@@ -684,16 +685,16 @@ import Turtle
 -- > $ ./example.hs
 -- > 
 -- > example.hs:8:7:
--- >     No instance for (Num Text)
+-- >     No instance for (Num Line)
 -- >       arising from the literal `4'
--- >     Possible fix: add an instance declaration for (Num Text)
+-- >     Possible fix: add an instance declaration for (Num Line)
 -- >     In the expression: 4
 -- >     In an equation for `str': str = 4
 --
 -- Haskell also automatically overloads numeric literals, too.  The compiler
 -- interprets integer literals as any type that implements the `Num` interface.
--- The `Text` type does not implement the `Num` interface, so we cannot
--- interpret integer literals as `Text` strings.
+-- The `Line` type does not implement the `Num` interface, so we cannot
+-- interpret integer literals as `Line` strings.
 
 -- $system
 --
@@ -734,7 +735,7 @@ import Turtle
 -- @
 -- `shell`
 --     :: Text         -- Command line
---     -> Shell Text   -- Standard input (as lines of \`Text\`)
+--     -> Shell Line   -- Standard input (as lines of \`Text\`)
 --     -> IO `ExitCode`  -- Exit code of the shell command
 -- @
 --
@@ -775,7 +776,7 @@ import Turtle
 -- `proc`
 --     :: Text         -- Program
 --     -> [Text]       -- Arguments
---     -> Shell Text   -- Standard input (as lines of \`Text\`)
+--     -> Shell Line   -- Standard input (as lines of \`Text\`)
 --     -> IO ExitCode  -- Exit code of the shell command
 -- @
 --
@@ -929,7 +930,7 @@ import Turtle
 -- @
 -- Prelude Turtle> view (`liftIO` readline)
 -- ABC\<Enter\>
--- Just \"ABC\"
+-- Just (Line "ABC")
 -- @
 --
 -- Another way to say that is:
@@ -1113,13 +1114,13 @@ import Turtle
 -- For example, you can write to standard output using the `stdout` utility:
 --
 -- @
--- `stdout` :: Shell Text -> IO ()
+-- `stdout` :: Shell Line -> IO ()
 -- `stdout` s = sh (do
 --     txt <- s
 --     liftIO (echo txt) )
 -- @
 --
--- `stdout` outputs each `Text` value on its own line:
+-- `stdout` outputs each `Line` value on its own line:
 --
 -- > Prelude Turtle> stdout "Line 1"
 -- > Line 1
@@ -1127,11 +1128,11 @@ import Turtle
 -- > Line 1
 -- > Line 2
 --
--- Another useful stream is `stdin`, which emits one line of `Text` per line of
+-- Another useful stream is `stdin`, which emits one `Line` value per line of
 -- standard input:
 --
 -- @
--- `stdin` :: Shell Text
+-- `stdin` :: Shell Line
 -- @
 --
 -- Let's combine `stdin` and `stdout` to forward all input from standard input
@@ -1194,8 +1195,8 @@ import Turtle
 -- @
 -- `inshell`
 --     :: Text    -- Command line
---     -> Shell Text  -- Standard input to feed to program
---     -> Shell Text  -- Standard output produced by program
+--     -> Shell Line  -- Standard input to feed to program
+--     -> Shell Line  -- Standard output produced by program
 -- @
 --
 -- This means you can use `inshell` to embed arbitrary external utilities as
@@ -1212,8 +1213,8 @@ import Turtle
 -- `inproc`
 --     :: Text        -- Program
 --     -> [Text]      -- Arguments
---     -> Shell Text  -- Standard input to feed to program
---     -> Shell Text  -- Standard output produced by program
+--     -> Shell Line  -- Standard input to feed to program
+--     -> Shell Line  -- Standard output produced by program
 -- @
 --
 -- Using `inproc`, you would write:
@@ -1238,7 +1239,7 @@ import Turtle
 -- Let's look at the type of `grep`:
 --
 -- @
--- `grep` :: Pattern a -> Shell Text -> Shell Text
+-- `grep` :: Pattern a -> Shell Line -> Shell Line
 -- @
 --
 -- The first argument of `grep` is actually a `Pattern`, which implements
@@ -1655,7 +1656,7 @@ import Turtle
 -- > 
 -- > parser :: Parser Command
 -- > parser
--- >     =   fmap IncreaseVolume 
+-- >     =   fmap IncreaseVolume
 -- >             (subcommand "up" "Turn the volume up"
 -- >                 (argInt "amount" "How much to increase the volume") )
 -- >     <|> fmap DecreaseVolume
@@ -1665,8 +1666,8 @@ import Turtle
 -- > main = do
 -- >     x <- options "Volume adjuster" parser
 -- >     case x of
--- >         IncreaseVolume n -> echo (format ("Increasing the volume by "%d) n)
--- >         DecreaseVolume n -> echo (format ("Decreasing the volume by "%d) n)
+-- >         IncreaseVolume n -> printf ("Increasing the volume by "%d%"\n") n
+-- >         DecreaseVolume n -> printf ("Decreasing the volume by "%d%"\n") n
 --
 -- This will provide `--help` output at both the top level and for each
 -- subcommand:

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -1,5 +1,5 @@
 Name: turtle
-Version: 1.2.8
+Version: 1.3.0
 Cabal-Version: >=1.10
 Build-Type: Simple
 License: BSD3
@@ -78,6 +78,7 @@ Library
         Turtle.Pattern,
         Turtle.Shell,
         Turtle.Options,
+        Turtle.Line,
         Turtle.Prelude,
         Turtle.Tutorial
     GHC-Options: -Wall


### PR DESCRIPTION
A sketch of a newtype wrapper for text values that do not contain newlines. I'm not sure where the assumption about newlines is made in the library and where it isn't, so I didn't use `Line` anywhere except `grep` as per #162.