### PR TITLE
Replace header with program description in subcommands

### DIFF
--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -235,4 +235,4 @@ subcommand cmdName desc p =
 
     info = Opts.info
         (Opts.helper <*> p)
-        (Opts.headerDoc (Just (getDescription desc)))
+        (Opts.progDescDoc (Just (getDescription desc)))


### PR DESCRIPTION
Top level before:
```
$ foo --help
Foo description

Usage: foo cmd

Available options:
  -h,--help                Show this help text

Available commands:
  cmd
```
Top level after:
```
$ foo --help
Foo description

Usage: foo cmd

Available options:
  -h,--help                Show this help text

Available commands:
  cmd                      Cmd description
```
Subcommand before:
```
$ foo cmd --help
Cmd description

Usage: foo cmd BLAH

Available options:
  -h,--help                Show this help text
  BLAH                     Blah description
```
Subcommand after:
```
$ foo cmd --help
Usage: foo cmd BLAH
  Cmd description

Available options:
  -h,--help                Show this help text
  BLAH                     Blah description
```