### PR TITLE
Add subcommandGroup

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
 resolver: lts-6.0
+extra-deps:
+  - optparse-applicative-0.13.0.0

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -64,7 +64,7 @@ Library
         text                               < 1.3 ,
         time                               < 1.7 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
-        optparse-applicative >= 0.11    && < 0.14,
+        optparse-applicative >= 0.13    && < 0.14,
         optional-args        >= 1.0     && < 2.0 ,
         unix-compat          >= 0.4     && < 0.5
     if os(windows)


### PR DESCRIPTION
The code came out a bit awkward because the underlying API is awkward. The entire command group is given a metavar (rather than each subcommand), so I just manually emulate the metavar generated by `<|>` (this is also the reason I took the entire command group as a monolithic list, rather than use `<>` to build one up)
