### PR TITLE
Added functions to help out with headers in streaming.

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -189,6 +189,8 @@ module Turtle.Prelude (
 
     -- * Text
     , cut
+    , headerMap
+    , headerRMap
 
     -- * Subprocess management
     , proc
@@ -1622,6 +1624,25 @@ cache file s = do
 cut :: Pattern a -> Text -> [Text]
 cut pattern txt = head (match (selfless chars `sepBy` pattern) txt)
 -- This `head` should be safe ... in theory
+
+-- | Map a function that uses the header over the stream.
+headerMap :: (a -> a -> a) -> Shell a -> Shell (Maybe a)
+headerMap f s = do
+    header <- fold s Control.Foldl.head
+    case header of
+        Nothing  -> return Nothing
+        (Just h) -> cat [ return . Just $ h
+                        , fmap (Just . f h) s
+                        ]
+
+-- | Map a function that uses the header over the stream, removing the header,
+-- allowing a more flexibility.
+headerRMap :: (a -> a -> b) -> Shell a -> Shell (Maybe b)
+headerRMap f s = do
+    header <- fold s Control.Foldl.head
+    case header of
+        Nothing -> return Nothing
+        (Just h) -> fmap (Just . f h) $ s
 
 -- | Get the current time
 date :: MonadIO io => io UTCTime


### PR DESCRIPTION
I have huge needs for streaming functions that take the first line across the stream for data processing. For instance, filtering based on a column name of a csv file, adding columns, columns abound, so I believe headerMap and headerRMap can fill this need. For instance (in an overly wordy way as it's a general function, not necessarily for text or the like),

> view (headerRMap (\h l -> mappend (h !! 3) (l !! 2)) . fmap (T.splitOn "," . lineToText) $ Turtle.input "test.csv")  
> Just "testa"
> Just "test4"
> Just "testalfred"

It would be fun to implement, in addition, a version meant solely for csv files, but that would require more dependencies (to make my life easier) which you would probably not want. For now, these functions would be very useful to have in the Prelude.
