### PR TITLE
Fix broken pipe issue with proc/shell functions

### DIFF
--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -1,0 +1,16 @@
+module Turtle.Internal
+    ( ignoreSIGPIPE
+    ) where
+
+import Control.Exception (handle, throwIO)
+import Foreign.C.Error (Errno(..), ePIPE)
+import GHC.IO.Exception (IOErrorType(..), IOException(..))
+
+ignoreSIGPIPE :: IO () -> IO ()
+ignoreSIGPIPE = handle (\e -> case e of
+    IOError
+        { ioe_type = ResourceVanished
+        , ioe_errno = Just ioe }
+        | Errno ioe == ePIPE -> return ()
+    _ -> throwIO e
+    )

--- a/test/RegressionBrokenPipe.hs
+++ b/test/RegressionBrokenPipe.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Control.Monad
+import System.Timeout
+import Turtle
+import qualified Turtle.Bytes as Bytes
+
+main :: IO ()
+main = do
+    echo "proc (text)"
+    void $ timeout duration $ forever $ proc "true" [] message
+    echo "procStrict (text)"
+    void $ timeout duration $ forever $ procStrict "true" [] message
+    echo "procStrictWithErr (text)"
+    void $ timeout duration $ forever $ procStrictWithErr "true" [] message
+    echo "proc (bytes)"
+    void $ timeout duration $ forever $ Bytes.proc "true" [] message
+    echo "procStrict (bytes)"
+    void $ timeout duration $ forever $ Bytes.procStrict "true" [] message
+    echo "procStrictWithErr (bytes)"
+    void $ timeout duration $ forever $ Bytes.procStrictWithErr "true" [] message
+  where
+    message :: IsString s => s
+    message = "foobarbaz"
+    duration = 3 * 10^ (6 :: Int)

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -94,6 +94,16 @@ test-suite tests
         base    >= 4   && < 5   ,
         doctest >= 0.7 && < 0.12
 
+test-suite regression-broken-pipe
+    Type: exitcode-stdio-1.0
+    HS-Source-Dirs: test
+    Main-Is: RegressionBrokenPipe.hs
+    GHC-Options: -Wall -threaded
+    Default-Language: Haskell2010
+    Build-Depends:
+        base    >= 4   && < 5   ,
+        turtle
+
 benchmark bench
     Type: exitcode-stdio-1.0
     HS-Source-Dirs: bench

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -81,6 +81,8 @@ Library
         Turtle.Line,
         Turtle.Prelude,
         Turtle.Tutorial
+    Other-Modules:
+        Turtle.Internal
     GHC-Options: -Wall
     Default-Language: Haskell2010
 


### PR DESCRIPTION
Relevant: #102

The first commit [demonstrates](https://travis-ci.org/maoe/Haskell-Turtle-Library/jobs/176547633#L2338) the issue.

Here is what's happening:
1. `system` creates a pipe to feed input to the command it's executing
2. the command exits immediately, so the pipe is closed
3. `feedIn` tries to `write(2)` to the closed pipe, which ends up with broken pipe

Note that `hClose` also can cause broken pipe as it flushes the buffer before closing the handle.

The issue can be worked around by ignoring `SIGPIPE` as the `process` package does in `readCreateProcess` etc.

PS: I'm not sure why `turtle` needs to call `close` twice in `system` and the like. Isn't it sufficient to call it once in `feedIn`?