### PR TITLE
More flexible command line flags

### DIFF
--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -76,6 +76,7 @@ module Turtle (
     , module Control.Monad
     , module Control.Monad.IO.Class
     , module Data.Monoid
+    , module Data.Semigroup
     , module Control.Monad.Managed
     , module Filesystem.Path.CurrentOS
     , Fold(..)
@@ -117,7 +118,8 @@ import Control.Monad
     , unless
     )
 import Control.Monad.IO.Class (MonadIO(..))
-import Data.Monoid (Monoid(..), (<>))
+import Data.Monoid (Monoid(..))
+import Data.Semigroup (Semigroup(..))
 import Data.String (IsString(..))
 import Filesystem.Path.CurrentOS
     ( FilePath

--- a/src/Turtle/Line.hs
+++ b/src/Turtle/Line.hs
@@ -24,6 +24,7 @@ import Data.String
 import Data.Monoid
 #endif
 import Data.Maybe
+import Data.Semigroup
 import Data.Typeable
 import Control.Exception
 
@@ -57,7 +58,7 @@ instance Exception NewlineForbidden
 
 -- | A line of text (does not contain newlines).
 newtype Line = Line Text
-  deriving (Eq, Ord, Show, Monoid)
+  deriving (Eq, Ord, Show, Monoid, Semigroup)
 
 instance IsString Line where
   fromString = fromMaybe (throw NewlineForbidden) . textToLine . fromString

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -10,8 +10,8 @@
 -- > import Turtle
 -- >
 -- > parser :: Parser (Text, Int)
--- > parser = (,) <$> optText (longFlag "name" <> shortFlag 'n') "name" "Your first name"
--- >              <*> optInt  (longFlag "age")                   "age"  "Your current age"
+-- > parser = (,) <$> optText ("name" <> shortFlag 'n') "name" "Your first name"
+-- >              <*> optInt  "age"                     "age"  "Your current age"
 -- >
 -- > main = do
 -- >     (name, age) <- options "Greeting script" parser
@@ -75,7 +75,7 @@ module Turtle.Options
 import Data.Monoid
 import Data.Foldable
 import qualified Data.Semigroup as Semigroup
-import Data.String (IsString)
+import Data.String (IsString(..))
 import Text.Read (readMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -121,6 +121,9 @@ instance Semigroup.Semigroup FlagName where
         { flagShortName = flagShortName a <> flagShortName b
         , flagLongName = flagLongName a <> flagLongName b
         }
+
+instance IsString FlagName where
+    fromString xs = longFlag (fromString xs)
 
 -- | A short name for a flag
 shortFlag :: ShortName -> FlagName

--- a/src/Turtle/Pattern.hs
+++ b/src/Turtle/Pattern.hs
@@ -114,6 +114,7 @@ import Control.Monad.Trans.State
 import Data.Char
 import Data.List (foldl')
 import Data.Monoid
+import qualified Data.Semigroup as Semigroup
 import Data.String (IsString(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -122,6 +123,9 @@ import Prelude -- Fix redundant import warnings
 -- | A fully backtracking pattern that parses an @\'a\'@ from some `Text`
 newtype Pattern a = Pattern { runPattern :: StateT Text [] a }
     deriving (Functor, Applicative, Monad, Alternative, MonadPlus)
+
+instance Semigroup.Semigroup a => Semigroup.Semigroup (Pattern a) where
+    (<>) = liftA2 (Semigroup.<>)
 
 instance Monoid a => Monoid (Pattern a) where
     mempty  = pure mempty

--- a/src/Turtle/Shell.hs
+++ b/src/Turtle/Shell.hs
@@ -77,6 +77,7 @@ import Control.Monad.Managed (MonadManaged(..), with)
 import Control.Foldl (Fold(..), FoldM(..))
 import qualified Control.Foldl as Foldl
 import Data.Monoid
+import qualified Data.Semigroup as Semigroup
 import Data.String (IsString(..))
 import Prelude -- Fix redundant import warnings
 
@@ -148,6 +149,9 @@ instance MonadManaged Shell where
         x  <- begin
         x' <- with resource (step x)
         done x' )
+
+instance Semigroup.Semigroup a => Semigroup.Semigroup (Shell a) where
+    (<>) = liftA2 (Semigroup.<>)
 
 instance Monoid a => Monoid (Shell a) where
     mempty  = pure mempty

--- a/src/Turtle/Tutorial.hs
+++ b/src/Turtle/Tutorial.hs
@@ -1619,8 +1619,8 @@ import Turtle
 -- > import Prelude hiding (FilePath)
 -- > 
 -- > parser :: Parser (FilePath, FilePath)
--- > parser = (,) <$> optPath (longFlag "src"  <> shortFlag 's') "path" "The source file"
--- >              <*> optPath (longFlag "dest" <> shortFlag 'd') "path" "The destination file"
+-- > parser = (,) <$> optPath ("src"  <> shortFlag 's') "path" "The source file"
+-- >              <*> optPath ("dest" <> shortFlag 'd') "path" "The destination file"
 -- >
 -- > main = do
 -- >     (src, dest) <- options "A simple `cp` utility" parser

--- a/src/Turtle/Tutorial.hs
+++ b/src/Turtle/Tutorial.hs
@@ -1619,9 +1619,9 @@ import Turtle
 -- > import Prelude hiding (FilePath)
 -- > 
 -- > parser :: Parser (FilePath, FilePath)
--- > parser = (,) <$> optPath "src"  's' "The source file"
--- >              <*> optPath "dest" 'd' "The destination file"
--- > 
+-- > parser = (,) <$> optPath (longFlag "src"  <> shortFlag 's') "path" "The source file"
+-- >              <*> optPath (longFlag "dest" <> shortFlag 'd') "path" "The destination file"
+-- >
 -- > main = do
 -- >     (src, dest) <- options "A simple `cp` utility" parser
 -- >     cp src dest
@@ -1629,18 +1629,18 @@ import Turtle
 -- This now lets us specify the arguments in terms of flags:
 --
 -- > $ ./cp
--- > Usage: cp.hs (-s|--src SRC) (-d|--dest DEST)
--- > 
+-- > Usage: cp.hs (-s|--src PATH) (-d|--dest PATH)
+-- >
 -- > $ ./cp --help
 -- > A simple `cp` utility
--- > 
--- > Usage: cp.hs (-s|--src SRC) (-d|--dest DEST)
--- > 
+-- >
+-- > Usage: cp.hs (-s|--src PATH) (-d|--dest PATH)
+-- >
 -- > Available options:
 -- >   -h,--help                Show this help text
--- >   -s,--src SRC             The source file
--- >   -d,--dest DEST           The destination file
--- > 
+-- >   -s,--src PATH            The source file
+-- >   -d,--dest PATH           The destination file
+-- >
 -- > $ ./cp --src file1.txt --dest file3.txt
 -- > $ cat file3.txt
 -- > Test

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -71,6 +71,8 @@ Library
         Build-Depends: Win32 >= 2.2.0.1 && < 2.4
     else
         Build-Depends: unix  >= 2.5.1.0 && < 2.8
+    if impl(ghc < 8.0)
+        Build-Depends: semigroups          < 0.19
     Exposed-Modules:
         Turtle,
         Turtle.Bytes,


### PR DESCRIPTION
This PR changes the way to define command line flags to get more flexibility. Specifically the option parsing library now:

* requires only one flag name which can be a short name or a long name
* is able to define multiple long/short names for a flag e.g. `switch ("dry" <> "dry-run" <> shortFlag 'n')` accepts `--dry`, `--dry-run`, and `-n`
* requires a separate metavariable name. This is necessary because there can be no long flag name which can be used as the metavariable. This is sometimes useful even with a long flag for clarity of the help message.

## Motivation

There are three reasons why I want this change.

1. I often would like to omit short flags for rarely-used options. This is currently impossible because all `optXXX` parsers always take an `ArgName` and a `ShortName`.
2. I sometimes would like to define a synonym for a flag so I can change a flag name without breaking existing systems.
3. I'd like to specify a custom metavariable if the flag takes some complex format.

## Implementation notes

`FlagName` is an abstract data type accompanied by smart constructors to keep an invariant: every option should at least have either a long name or a short name. It has an instance of `Semigroup` so we can add more names without introducing `mempty` which breaks the invariant.

## Migration notes

This is a breaking change. All existing code that use `optXXX` break. Fortunately, it's straightforward to fix the breakage:

* `ArgName` is a long option. If it's a string literal, it works as it is. Otherwise you can use `longFlag`.
* `shortFlag` is necessary to turn a `ShortName` to a `FlagName`. You can compose it with other flag names using `(Data.Semigroup.<>)`, which is re-exported from `Turtle`.
* `ArgName` now means the metavariable for the flag.

Look at the documentation changes in this PR for example.

Another type of breakage is the reexport of `Semigroup`'s `(<>)` from `Turtle`. It fails to compile if a module imports `(<>)` from `Data.Monoid`. I suspect it would become less problematic as `Data.Semigroup` gets popular.