### PR TITLE
Return an empty Line if textToLine is applied to an empty Text

### DIFF
--- a/src/Turtle/Line.hs
+++ b/src/Turtle/Line.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
 
 module Turtle.Line
   ( Line
@@ -88,6 +89,7 @@ linesToText =
 textToLine :: Text -> Maybe Line
 textToLine = fromSingleton . textToLines
   where
+    fromSingleton []  = Just (Line "")
     fromSingleton [a] = Just a
     fromSingleton _   = Nothing
 


### PR DESCRIPTION
Currently the `IsString` instance for `Line` doesn't accept an empty string as an input. This is a bit weird as, I think, an empty string is completely valid data to be used as a `Line`. This is in practice a source of partiality:

```
*Turtle> :set -XOverloadedStrings 
*Turtle> echo ""
*** Exception: NewlineForbidden
```

This PR fixes `textToLine` to return an empty `Line` if it's applied to an empty `Text`.