### PR TITLE
Correctly unmask exceptions when running subprocesses

### DIFF
--- a/test/RegressionMaskingException.hs
+++ b/test/RegressionMaskingException.hs
@@ -6,7 +6,7 @@ import qualified System.Timeout
 
 main :: IO ()
 main = do
-    m <- System.Timeout.timeout 1 (runManaged (do
+    m <- System.Timeout.timeout 1000000 (runManaged (do
         _ <- fork (shells "while true; do sleep 1; done" empty)
         return () ))
     case m of

--- a/test/RegressionMaskingException.hs
+++ b/test/RegressionMaskingException.hs
@@ -4,11 +4,9 @@ import Turtle
 
 import qualified System.Timeout
 
+-- This test fails by hanging
 main :: IO ()
-main = do
-    m <- System.Timeout.timeout 1000000 (runManaged (do
-        _ <- fork (shells "while true; do sleep 1; done" empty)
-        return () ))
-    case m of
-        Nothing -> die "Subprocess runners are incorrectly masking exceptions"
-        Just _  -> return ()
+main = runManaged (do
+    _ <- fork (shells "while true; do sleep 1; done" empty)
+    sleep 1
+    return () )

--- a/test/RegressionMaskingException.hs
+++ b/test/RegressionMaskingException.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Turtle
+
+import qualified System.Timeout
+
+main :: IO ()
+main = do
+    m <- System.Timeout.timeout 1 (runManaged (do
+        _ <- fork (shells "while true; do sleep 1; done" empty)
+        return () ))
+    case m of
+        Nothing -> die "Subprocess runners are incorrectly masking exceptions"
+        Just _  -> return ()

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -105,7 +105,17 @@ test-suite regression-broken-pipe
     GHC-Options: -Wall -threaded
     Default-Language: Haskell2010
     Build-Depends:
-        base    >= 4   && < 5   ,
+        base   >= 4 && < 5,
+        turtle
+
+test-suite regression-masking-exception
+    Type: exitcode-stdio-1.0
+    HS-Source-Dirs: test
+    Main-Is: RegressionMaskingException.hs
+    GHC-Options: -Wall -threaded
+    Default-Language: Haskell2010
+    Build-Depends:
+        base   >= 4 && < 5,
         turtle
 
 benchmark bench


### PR DESCRIPTION
Before this change the following code hangs:

    runManaged (do
        _ <- fork (shells "while true; do sleep 1; done" empty)
        return () )

... because of the following sequence of events:

*   `fork` forks the subprocess using `async` and registers a `cancel` function
    to be called when the `runManaged` block completes
*   `runManaged` completes immediately after that, so `cancel` gets called on
    the thread running the subprocess
*   `cancel` throws a `ThreadKilled` exception to the thread running the
    subprocess
*   `shells` internally uses `system`, which interally uses the following idiom:

    ```haskell
    let feedIn :: (forall a. IO a -> IO a) -> IO ()
        feedIn restore =
            restore (ignoreSIGPIPE (outhandle hIn s)) `finally` close hIn
    mask_ (withAsyncWithUnmask feedIn (\a -> Process.waitForProcess ph <* halt a) )
    ```

    ... which means that `outhandle` runs with exceptions unmasked but the
    `waitForProcess` does not!
*   The `outhandle` function running in the forked `feedIn` thread gets correctly
    terminated by the exception because it runs unmasked inside of the `restore`
*   However, the main thread running `waitForProcess` has exceptions still masked
*   Therefore, the `waitForProcess` does not complete, because it only can
    terminate under two conditions.  Either:
        *   `withAsyncWithUnmask` forwards exceptions from the forked thread to the
            main thread running `waitForProcess` to terminate the main thread
            * However, this doesn't work because the main `waitForProcess` masks
              any exceptions forwarded from the forked thread
        *   `waitForProcess` completes successfully, which only happens if the
            forked thread calls `terminateProcess`
            * However, the forked thread doesn't call `terminateProcess` if it
              fails with an exception

The solution is to correctly unmask the `waitForProcess` so that it correctly
receives any exceptions propagated from the forked thread.  I did this by using
`mask` to provide the `restore` function instead of `withAsyncWithUnmask`.

Another alternative solution would be to have the forked thread call
`terminateProcess` if any exceptions were thrown (which might still be worth
doing in a separate change), but I felt that signaling shutdown by correctly
propagating exceptions is a more reliable mechanism than signaling via the process
handle.

Several other functions use the same idiom, so I updated them to also unmask the
`waitForProcess` call.

I added a regression test for this behavior to ensure that forked subprocesses
terminate immediately.  This test fails before this change and succeeds after.