### PR TITLE
Update whichAll to honor OS-specific search path delimiter

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1251,8 +1251,8 @@ which cmd = fold (whichAll cmd) Control.Foldl.head
 whichAll :: FilePath -> Shell FilePath
 whichAll cmd = do
   Just paths <- need "PATH"
-  path <- select (Text.split (== ':') paths)
-  let path' = Filesystem.fromText path </> cmd
+  path <- select (Filesystem.splitSearchPathString . Text.unpack $ paths)
+  let path' = path </> cmd
 
   True <- testfile path'
 


### PR DESCRIPTION
This PR replaces the hard-coded search path delimiter of `':'` used in `Turtle.Prelude.whichAll` with `system-filepath`'s `splitSearchPathString`.

This gets `which` and `whichAll` working on Windows.  On Windows, the search path delimiter is a semicolon from both git bash and cmd.exe so `which`/`whichAll` were returning empty.