### PR TITLE
Fix cptree to copy files as files instead of directories

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1034,9 +1034,9 @@ cptree oldTree newTree = sh (do
     -- directory
     Just suffix <- return (Filesystem.stripPrefix (oldTree </> "") oldPath)
     let newPath = newTree </> suffix
-    isFile <- testfile newPath
+    isFile <- testfile oldPath
     if isFile
-        then cp oldPath newPath
+        then mktree (Filesystem.directory newPath) >> cp oldPath newPath
         else mktree newPath )
 
 -- | Remove a file


### PR DESCRIPTION
Fixes bug in Turtle 1.3.3's `cptree` function where files were being copied as directories.

Please see [this gist](https://gist.github.com/jship/be7da5d3649359d0e7a6f38731c707c2) for a minimal example that demonstrates the issue and can be run directly with Stack version >= 1.4.0 via `turtle-v133-cptree-bug.hs`.

The script in the gist sets up some test directories and copies them both with Turtle 1.3.3's `cptree` and the version of `cptree` in this PR.  The one copied with 1.3.3's `cptree' copies all the contents as directories and the one in this PR copies them as they are - file or directory.

This was tested on Windows 10.