### PR TITLE
Integration test for cptree

### DIFF
--- a/test/cptree.hs
+++ b/test/cptree.hs
@@ -6,18 +6,16 @@ import System.IO.Temp (withSystemTempDirectory)
 import Control.Monad (unless)
 
 check :: String -> Bool-> IO ()
-check errorMessage successs = unless successs $ error errorMessage
+check errorMessage successs = unless successs $ fail errorMessage
 
--- This test fails by hanging
 main :: IO ()
 main = withSystemTempDirectory "tempDir" (runTest . fromString)
 
 runTest :: Turtle.FilePath -> IO ()
 runTest tempDir = do
   let srcDirectory = tempDir </> "src"
-  mkdir srcDirectory
 
-  mkdir $ srcDirectory </> "directory"
+  mktree $ srcDirectory </> "directory"
   touch $ srcDirectory </> "directory" </> "file"
 
   let destDirectory = tempDir </> "dest"

--- a/test/cptree.hs
+++ b/test/cptree.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Turtle
+import Filesystem.Path.CurrentOS ()
+import System.IO.Temp (withSystemTempDirectory)
+import Control.Monad (unless)
+
+check :: String -> Bool-> IO ()
+check errorMessage successs = unless successs $ error errorMessage
+
+-- This test fails by hanging
+main :: IO ()
+main = withSystemTempDirectory "tempDir" (runTest . fromString)
+
+runTest :: Turtle.FilePath -> IO ()
+runTest tempDir = do
+  let srcDirectory = tempDir </> "src"
+  mkdir srcDirectory
+
+  mkdir $ srcDirectory </> "directory"
+  touch $ srcDirectory </> "directory" </> "file"
+
+  let destDirectory = tempDir </> "dest"
+
+  cptree srcDirectory destDirectory
+
+  testdir (destDirectory </> "directory") >>= check "cptree did not preserve directory"
+  testfile (destDirectory </> "directory" </> "file") >>= check "cptree did not preserve directory"

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -119,6 +119,18 @@ test-suite regression-masking-exception
         base   >= 4 && < 5,
         turtle
 
+test-suite cptree
+    Type: exitcode-stdio-1.0
+    HS-Source-Dirs: test
+    Main-Is: cptree.hs
+    GHC-Options: -Wall -threaded
+    Default-Language: Haskell2010
+    Build-Depends:
+        base   >= 4 && < 5,
+        temporary,
+        system-filepath >= 0.4,
+        turtle
+
 benchmark bench
     Type: exitcode-stdio-1.0
     HS-Source-Dirs: bench


### PR DESCRIPTION
I encounter the issue fixed by this PR: https://github.com/Gabriel439/Haskell-Turtle-Library/pull/235. (the issue still present on the version distributed by the latest, 8.15, lts of stack). I did not the commit that fix it, and I started wanted to fix the bug, I wrote this integration test that I could not success to make it fail because the bug was already fixed!

I do not know if you are interested in test but in case here my PR. I think it's good to have a test to prove bugfix work and to avoid regression.