### PR TITLE
Relaxing the upper bound of optparse-applicative to allow for the 0.14 release

### DIFF
--- a/turtle.cabal
+++ b/turtle.cabal
@@ -67,7 +67,7 @@ Library
         text                               < 1.3 ,
         time                               < 1.9 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
-        optparse-applicative >= 0.13    && < 0.14,
+        optparse-applicative >= 0.13    && < 0.15,
         optional-args        >= 1.0     && < 2.0 ,
         unix-compat          >= 0.4     && < 0.5
     if os(windows)


### PR DESCRIPTION
This change relaxes the upper bound of the `optparse-applicative` dependency to allow for the recent `0.14` release.

I built `turtle` with an overridden `optparse-applicative` derivation that provided the `0.14` version. The build succeeded without error.