### PR TITLE
Update tutorial

### DIFF
--- a/src/Turtle/Tutorial.hs
+++ b/src/Turtle/Tutorial.hs
@@ -1550,7 +1550,7 @@ import Turtle
 -- >              <*> argPath "dest" "The destination file"
 -- >
 -- > main = do
--- >     (src, dest) <- options "A simple `cp` script" parser
+-- >     (src, dest) <- options "A simple `cp` utility" parser
 -- >     cp src dest
 --
 -- If you run the script without any arguments, you will get an auto-generated


### PR DESCRIPTION
Replace "A simple `cp` script" with "A simple `cp` utility" to match example output