### PR TITLE
Add `uniq`, `nub` and `sorted` to the `Prelude`

### DIFF
--- a/turtle.cabal
+++ b/turtle.cabal
@@ -54,6 +54,7 @@ Library
         async                >= 2.0.0.0 && < 2.2 ,
         bytestring           >= 0.9.1.8 && < 0.11,
         clock                >= 0.4.1.2 && < 0.8 ,
+        containers           >= 0.5.0.0 && < 0.6 ,
         directory            >= 1.0.7   && < 1.4 ,
         foldl                >= 1.1     && < 1.4 ,
         hostname                           < 1.1 ,


### PR DESCRIPTION
I had to add `containers` to the dependencies, but I guess that is not a problem anyway.


- uniq: basically the same as the `uniq` commandline tool, discards adjacent duplicates
- nub: does a global removal of duplicates, at the cost of having a `Set` in memory.  We could improve on this by using a `hash`, but I think adding that would be a lot more changes, although it *is* better ;)
- sorted: This is not a function from and to `Shell`, because we have to run it to the end and then do the sorting.  I kept it the same as the commandline `sort`, so duplicates are *not* removed

The whole `IO` + `IORef` thing feels a little dirty though :D