### PR TITLE
Simplify `release.nix`

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -13,10 +13,6 @@ let
     packageOverrides = pkgs: {
       haskellPackages = pkgs.haskellPackages.override {
         overrides = haskellPackagesNew: haskellPackagesOld: {
-          optparse-applicative =
-            pkgs.haskell.lib.dontCheck
-              (haskellPackagesNew.callPackage ./optparse-applicative.nix { });
-
           turtle =
             haskellPackagesNew.callPackage ./default.nix { };
         };


### PR DESCRIPTION
Newer versions of `nixpkgs` have a sufficiently new version of
`optparse-applicative`, so there is no need to pin the version