### PR TITLE
Add `MonadCatch` instance for `Shell`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
-, containers, directory, doctest, foldl, hostname, managed
-, optional-args, optparse-applicative, process, semigroups, stdenv
-, stm, system-fileio, system-filepath, temporary, text, time
-, transformers, unix, unix-compat
+, containers, criterion, directory, doctest, exceptions, foldl
+, hostname, managed, optional-args, optparse-applicative, process
+, semigroups, stdenv, stm, system-fileio, system-filepath
+, temporary, text, time, transformers, unix, unix-compat
 }:
 mkDerivation {
   pname = "turtle";
@@ -10,11 +10,12 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     ansi-wl-pprint async base bytestring clock containers directory
-    foldl hostname managed optional-args optparse-applicative process
-    semigroups stm system-fileio system-filepath temporary text time
-    transformers unix unix-compat
+    exceptions foldl hostname managed optional-args
+    optparse-applicative process semigroups stm system-fileio
+    system-filepath temporary text time transformers unix unix-compat
   ];
   testHaskellDepends = [ base doctest system-filepath temporary ];
+  benchmarkHaskellDepends = [ base criterion text ];
   description = "Shell programming, Haskell-style";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -56,6 +56,7 @@ Library
         clock                >= 0.4.1.2 && < 0.8 ,
         containers           >= 0.5.0.0 && < 0.6 ,
         directory            >= 1.0.7   && < 1.4 ,
+        exceptions           >= 0.4     && < 0.9 ,
         foldl                >= 1.1     && < 1.4 ,
         hostname                           < 1.1 ,
         managed              >= 1.0.3   && < 1.1 ,


### PR DESCRIPTION
Fixes #259

This is a breaking change that requires changing the internal type that
`Shell` uses from `FoldM` to `FoldIO`.  In practice, most code should
work without any issues and the code that is affected can be fixed by
just replacing `Shell` with `_Shell`.  See the discussion in #259 which
explains why this change is necessary.

This also slightly changes the semantics of `FoldM`-based folds by
lazily deferring the @begin@ step of the `FoldM` until the first
@step@