### PR TITLE
Allow 'err' and 'echo' to take in multiline text

### DIFF
--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -46,6 +46,7 @@ module Turtle.Format (
     , (%)
     , format
     , printf
+    , eprintf
     , makeFormat
 
     -- * Parameters
@@ -76,6 +77,7 @@ import Data.Word
 import Filesystem.Path.CurrentOS (FilePath, toText)
 import Numeric (showEFloat, showFFloat, showGFloat, showHex, showOct)
 import Prelude hiding ((.), id, FilePath)
+import qualified System.IO as IO
 import Turtle.Line (Line)
 
 import qualified Data.Text.IO as Text
@@ -112,6 +114,14 @@ Hello, world!
 -}
 printf :: MonadIO io => Format (io ()) r -> r
 printf fmt = fmt >>- (liftIO . Text.putStr)
+
+{-| Print a `Format` string to standard err (without a trailing newline)
+
+>>> eprintf ("Hello, "%s%"!\n") "world"
+Hello, world!
+-}
+eprintf :: MonadIO io => Format (io ()) r -> r
+eprintf fmt = fmt >>- (liftIO . Text.hPutStr IO.stderr)
 
 -- | Create your own format specifier
 makeFormat :: (a -> Text) -> Format r (a -> r)

--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -856,12 +856,12 @@ inshellWithErr cmd = streamWithErr (Process.shell (unpack cmd))
     To print more than one line see `Turtle.Format.printf`, which also supports
     formatted output
 -}
-echo :: MonadIO io => Line -> io ()
-echo line = liftIO (Text.putStrLn (lineToText line))
+echo :: MonadIO io => Text -> io ()
+echo text = liftIO (Text.putStrLn text)
 
 -- | Print exactly one line to @stderr@
-err :: MonadIO io => Line -> io ()
-err line = liftIO (Text.hPutStrLn IO.stderr (lineToText line))
+err :: MonadIO io => Text -> io ()
+err text = liftIO (Text.hPutStrLn IO.stderr text)
 
 {-| Read in a line from @stdin@
 
@@ -1478,7 +1478,7 @@ inhandle handle = Shell (\(FoldM step begin done) -> do
 stdout :: MonadIO io => Shell Line -> io ()
 stdout s = sh (do
     line <- s
-    liftIO (echo line) )
+    liftIO (echo $ lineToText line) )
 
 -- | Stream lines of `Text` to a file
 output :: MonadIO io => FilePath -> Shell Line -> io ()
@@ -1504,7 +1504,7 @@ append file s = sh (do
 stderr :: MonadIO io => Shell Line -> io ()
 stderr s = sh (do
     line <- s
-    liftIO (err line) )
+    liftIO (err $ lineToText line) )
 
 -- | Read in a stream's contents strictly
 strict :: MonadIO io => Shell Line -> io Text


### PR DESCRIPTION
The `Line` type enforces a semantics that disallow having newlines in the input, but personally I find it a valid use case to `echo` or `err` text with newlines in it - in which case the defined behavior is to print the text and then append a newline in the end. As long as this 'defined behavior' is sufficiently intuitive / sensible to users, we shouldn't need to restrict the acceptable input - what do you think?