### PR TITLE
Document `inproc`: throws `ExitCode` for non-zero exit codes

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -678,6 +678,8 @@ inproc cmd args = stream (Process.proc (unpack cmd) (map unpack args))
     injection if you template the command line with untrusted input
 
     The command inherits @stderr@ for the current process
+
+    Throws an `ExitCode` exception if the command returns a non-zero exit code
 -}
 inshell
     :: Text


### PR DESCRIPTION
hello, 

I think it is worth mentionning that `inproc` throws `ExitCode`, because without reading the source code, it is not obvious that `inproc` is based on `stream`.

Thank you for this nice library, BTW!
Damien