### PR TITLE
Loosened upper bound for Win32

### DIFF
--- a/stack-lts-10.yaml
+++ b/stack-lts-10.yaml
@@ -1,0 +1,2 @@
+resolver: lts-10.2
+extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-7.11
+resolver: lts-7.24
 extra-deps:
 - optparse-applicative-0.13.0.0

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -73,7 +73,7 @@ Library
         optional-args        >= 1.0     && < 2.0 ,
         unix-compat          >= 0.4     && < 0.6
     if os(windows)
-        Build-Depends: Win32 >= 2.2.0.1 && < 2.4
+        Build-Depends: Win32 >= 2.2.0.1 && < 2.6
     else
         Build-Depends: unix  >= 2.5.1.0 && < 2.8
     Exposed-Modules:


### PR DESCRIPTION
In response to #278. The same tests seem to break with and without this change (`regression-broken-pipe` + `regression-masking-exception`) for `stack test --fast --stack-yaml=stack-lts-10.yaml`.