### PR TITLE
Fix `invert`

### DIFF
--- a/src/Turtle/Pattern.hs
+++ b/src/Turtle/Pattern.hs
@@ -444,11 +444,15 @@ signed p = do
 []
 >>> match (invert "A") "B"
 [()]
+>>> match (invert "A") "AA"
+[()]
 -}
 invert :: Pattern a -> Pattern ()
-invert p = Pattern (StateT (\str -> case runStateT (runPattern p) str of
-    [] -> [((), "")]
-    _  -> [] ))
+invert p = Pattern (StateT f)
+  where
+    f str = case match p str of
+        [] -> [((), "")]
+        _  -> []
 
 {-| Match a `Char`, but return `Text`
 


### PR DESCRIPTION
Fixes #296

`invert` would reject patterns that only matched a prefix of the string, and
this change fixes `invert` to only reject patterns that match the entire
string.