### PR TITLE
Refactor Nix code

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,35 @@
-{ mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
-, containers, criterion, directory, doctest, exceptions, foldl
-, hostname, managed, optional-args, optparse-applicative, process
-, semigroups, stdenv, stm, system-fileio, system-filepath
-, temporary, text, time, transformers, unix, unix-compat
-}:
-mkDerivation {
-  pname = "turtle";
-  version = "1.5.9";
-  src = ./.;
-  libraryHaskellDepends = [
-    ansi-wl-pprint async base bytestring clock containers directory
-    exceptions foldl hostname managed optional-args
-    optparse-applicative process semigroups stm system-fileio
-    system-filepath temporary text time transformers unix unix-compat
-  ];
-  testHaskellDepends = [ base doctest system-filepath temporary ];
-  benchmarkHaskellDepends = [ base criterion text ];
-  description = "Shell programming, Haskell-style";
-  license = stdenv.lib.licenses.bsd3;
-}
+let
+  fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
+
+  nixpkgs = fetchNixpkgs {
+    rev = "804060ff9a79ceb0925fe9ef79ddbf564a225d47";
+
+    sha256 = "01pb6p07xawi60kshsxxq1bzn8a0y4s5jjqvhkwps4f5xjmmwav3";
+
+    outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
+  };
+
+  readDirectory = import ./nix/readDirectory.nix;
+
+  config = {
+    packageOverrides = pkgs: {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides =
+          let
+            manualOverrides = haskellPackagesNew: haskellPackagesOld: {
+            };
+
+          in
+            pkgs.lib.composeExtensions (readDirectory ./nix) manualOverrides;
+      };
+    };
+  };
+
+  pkgs =
+    import nixpkgs { inherit config; };
+
+in
+  { inherit (pkgs.haskellPackages) turtle;
+
+    shell = (pkgs.haskell.lib.doBenchmark pkgs.haskellPackages.turtle).env;
+  }

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,49 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 fixed-output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+if (0 <= builtins.compareVersions builtins.nixVersion "1.12")
+
+# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+then (
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = outputSha256;
+  })
+
+# This hack should at least work for Nix 1.11
+else (
+  (rec {
+    tarball = import <nix/fetchurl.nix> {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
+    builtin-paths = import <nix/config.nix>;
+      
+    script = builtins.toFile "nixpkgs-unpacker" ''
+      "$coreutils/mkdir" "$out"
+      cd "$out"
+      "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+    '';
+
+    nixpkgs = builtins.derivation ({
+      name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+      builder = builtins.storePath builtin-paths.shell;
+
+      args = [ script ];
+
+      inherit tarball system;
+
+      tar       = builtins.storePath builtin-paths.tar;
+      gzip      = builtins.storePath builtin-paths.gzip;
+      coreutils = builtins.storePath builtin-paths.coreutils;
+    } // (if null == outputSha256 then { } else {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = outputSha256;
+    }));
+  }).nixpkgs)

--- a/nix/readDirectory.nix
+++ b/nix/readDirectory.nix
@@ -1,0 +1,14 @@
+directory:
+
+haskellPackagesNew: haskellPackagesOld:
+  let
+    haskellPaths = builtins.attrNames (builtins.readDir directory);
+
+    toKeyVal = file: {
+      name  = builtins.replaceStrings [ ".nix" ] [ "" ] file;
+
+      value = haskellPackagesNew.callPackage (directory + "/${file}") { };
+    };
+
+  in
+    builtins.listToAttrs (map toKeyVal haskellPaths)

--- a/nix/turtle.nix
+++ b/nix/turtle.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
+, containers, criterion, directory, doctest, exceptions, foldl
+, hostname, managed, optional-args, optparse-applicative, process
+, semigroups, stdenv, stm, system-fileio, system-filepath
+, temporary, text, time, transformers, unix, unix-compat
+}:
+mkDerivation {
+  pname = "turtle";
+  version = "1.5.9";
+  src = ./..;
+  libraryHaskellDepends = [
+    ansi-wl-pprint async base bytestring clock containers directory
+    exceptions foldl hostname managed optional-args
+    optparse-applicative process semigroups stm system-fileio
+    system-filepath temporary text time transformers unix unix-compat
+  ];
+  testHaskellDepends = [ base doctest system-filepath temporary ];
+  benchmarkHaskellDepends = [ base criterion text ];
+  description = "Shell programming, Haskell-style";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,28 +1,5 @@
-# You can build this repository using Nix by running:
-#
-#     $ nix-build -A turtle release.nix
-#
-# You can also open up this repository inside of a Nix shell by running:
-#
-#     $ nix-shell -A turtle.env release.nix
-#
-# ... and then Nix will supply the correct Haskell development environment for
-# you
 let
-  config = {
-    packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override {
-        overrides = haskellPackagesNew: haskellPackagesOld: {
-          turtle =
-            haskellPackagesNew.callPackage ./default.nix { };
-        };
-      };
-    };
-  };
-
-  pkgs =
-    import <nixpkgs> { inherit config; };
+  default = import ./default.nix;
 
 in
-  { turtle = pkgs.haskellPackages.turtle;
-  }
+  { inherit (default) turtle; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix).turtle.env
+(import ./default.nix).shell


### PR DESCRIPTION
This pins `nixpkgs` and also uses `readDirectory` for ease of testing changes
to dependencies