### PR TITLE
Don't forward broken pipe exceptions when using `inproc`

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -734,12 +734,12 @@ stream p s = do
     mvar <- liftIO (newMVar False)
     let close handle = do
             modifyMVar_ mvar (\finalized -> do
-                unless finalized (hClose handle)
+                unless finalized (ignoreSIGPIPE (hClose handle))
                 return True )
 
     (hIn, hOut, ph) <- using (managed (bracket open (\(hIn, _, ph) -> close hIn >> Process.terminateProcess ph)))
     let feedIn :: (forall a. IO a -> IO a) -> IO ()
-        feedIn restore = restore (outhandle hIn s) `finally` close hIn
+        feedIn restore = restore (ignoreSIGPIPE (outhandle hIn s)) `finally` close hIn
 
     a <- using
         (managed (\k ->
@@ -775,12 +775,12 @@ streamWithErr p s = do
     mvar <- liftIO (newMVar False)
     let close handle = do
             modifyMVar_ mvar (\finalized -> do
-                unless finalized (hClose handle)
+                unless finalized (ignoreSIGPIPE (hClose handle))
                 return True )
 
     (hIn, hOut, hErr, ph) <- using (managed (bracket open (\(hIn, _, _, ph) -> close hIn >> Process.terminateProcess ph)))
     let feedIn :: (forall a. IO a -> IO a) -> IO ()
-        feedIn restore = restore (outhandle hIn s) `finally` close hIn
+        feedIn restore = restore (ignoreSIGPIPE (outhandle hIn s)) `finally` close hIn
 
     queue <- liftIO TQueue.newTQueueIO
     let forwardOut :: (forall a. IO a -> IO a) -> IO ()


### PR DESCRIPTION
Fixes #318

In 8403923ceafe3737c0e2affaae606cce1ae5b600 we added the
`ignoreSIGPIPE` utility to avoid retransmitting broken pipe
exceptions from upstream processes, but this fix was missing
from the `inproc` and `inprocWithErr`.  This change updates
those utilities to also ignore SIGPIPE exceptions.