### PR TITLE
fixes possible chmod bug

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1253,9 +1253,9 @@ chmod modifyPermissions path = liftIO (do
     let permissions' = fromSystemDirectoryPermissions permissions
     let permissions'' = modifyPermissions permissions'
         changed = permissions' /= permissions''
-    let permissions''' = toSystemDirectoryPermissions permissions'
+    let permissions''' = toSystemDirectoryPermissions permissions''
     when changed (Directory.setPermissions path' permissions''')
-    return permissions' )
+    return permissions'' )
 
 -- | Get a file or directory's user permissions
 getmod :: MonadIO io => FilePath -> io Permissions


### PR DESCRIPTION
Apologies for such a low value PR, and if I have misunderstood the intentions of any of the functions.

I was trying to use the chmod function recently and noticed that it was failing to change the permissions of any paths. 

This seems to be because it is calculating the new permissions and then writing back the old ones. This changes it to write back the new ones, which gives it behaviour closer to what I'd expect from reading the documentation.