### PR TITLE
Fix shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./default.nix).shell
+((import ./default.nix){}).shell


### PR DESCRIPTION
Running nix-shell with nix 2.3.1 results in the following error:
```
error: value is a function while a set was expected, at (string):1:1
```
At least with the latest nix, (import ./default.nix) is a function, not a set. This patch adds a function application to fix it.