### PR TITLE
Remove an irrelevant doctest comment

### DIFF
--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -2038,8 +2038,6 @@ pattern GB { gigabytes } <- (\(MB x) -> x `div` 1000 -> gigabytes)
 
 >>> format sz (TB 42)
 "42.0 TB"
->>> let MB n = GB 1 in n
-1000
 >>> let GB n = TB 1 in n
 1000
 -}


### PR DESCRIPTION
This doctest section is for the `TB` pattern synonym but this particular example doesn't use `TB` at all. It looks like I forgot to delete these lines when copy-pasting doctest comments in #383.