### PR TITLE
Build against `optparse-applicative-0.16.0.0`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,10 @@
-{ compiler ? "ghc864" }:
+{ compiler ? "ghc865" }:
 
 let
   nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOs/nixpkgs/archive/312a059bef8b29b4db4e73dc02ff441cab7bb26d.tar.gz";
+    url = "https://github.com/NixOs/nixpkgs/archive/d8e0ade97ad89cd7ea4452e41b4abcaf7e04a8b7.tar.gz";
 
-    sha256 = "1j52yvkhw1inp6ilpqy81xv1bbwgwqjn0v9647whampkqgn6dxhk";
+    sha256 = "1rm6z9cch0kld1742inpsch06n97qik30a3njglvq52l8g9xw2jj";
   };
 
   config = {};
@@ -16,14 +16,15 @@ let
           overrides =
             let
               packageSources = pkgsNew.haskell.lib.packageSourceOverrides {
-                "fail" = "4.9.0.0";
-
                 "turtle" = ./.;
               };
 
               manualOverrides = haskellPackagesNew: haskellPackagesOld: {
                 system-fileio =
                   pkgsNew.haskell.lib.dontCheck haskellPackagesOld.system-fileio;
+
+                optparse-applicative =
+                  haskellPackagesNew.optparse-applicative_0_16_0_0;
               };
 
               default = old.overrides or (_: _: {});

--- a/optparse-applicative.nix
+++ b/optparse-applicative.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "optparse-applicative";
+  version = "0.16.0.0";
+  sha256 = "09c53c339c41167701343afaeccd5993c6bd827290a2b30053f2a7375555cb2b";
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
+  homepage = "https://github.com/pcapriotti/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -284,7 +284,7 @@ argParseToReadM f = do
     s <- Opts.readerAsk
     case f (Text.pack s) of
         Just a -> return a
-        Nothing -> Opts.readerAbort Opts.ShowHelpText
+        Nothing -> Opts.readerAbort (Opts.ShowHelpText Nothing)
 
 {-| Create a sub-command that parses `CommandName` and then parses the rest
     of the command-line arguments

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -68,7 +68,7 @@ Library
         text                 >= 1.0.0   && < 1.3 ,
         time                               < 1.10,
         transformers         >= 0.2.0.0 && < 0.6 ,
-        optparse-applicative >= 0.13    && < 0.16,
+        optparse-applicative >= 0.16    && < 0.17,
         optional-args        >= 1.0     && < 2.0 ,
         unix-compat          >= 0.4     && < 0.6
     if os(windows)


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/5597