### PR TITLE
Tutorial: Mark up «--help» correctly in sentence about subcommand help

### DIFF
--- a/src/Turtle/Tutorial.hs
+++ b/src/Turtle/Tutorial.hs
@@ -1739,7 +1739,7 @@ import Turtle
 -- >         IncreaseVolume n -> printf ("Increasing the volume by "%d%"\n") n
 -- >         DecreaseVolume n -> printf ("Decreasing the volume by "%d%"\n") n
 --
--- This will provide `--help` output at both the top level and for each
+-- This will provide @--help@ output at both the top level and for each
 -- subcommand:
 --
 -- > $ ./options --help


### PR DESCRIPTION
Currently it's rendered as
> This will provide \`--help\` output at both the top level and for each subcommand:

on https://hackage.haskell.org/package/turtle-1.6.2/docs/Turtle-Tutorial.html when it should be
> This will provide `--help` output at both the top level and for each subcommand:

instead.